### PR TITLE
OPGC corrected xml files following Rossana Paciello comments

### DIFF
--- a/examples/WP11/DynVolc.xml
+++ b/examples/WP11/DynVolc.xml
@@ -24,7 +24,7 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 			<dct:issued>2015-10-01T09:00:00</dct:issued><!-- Date of Publication -->
 			<dct:modified>2017-06-26T11:00:00</dct:modified><!-- Date of Revision -->
 			<dct:language><!-- Language -->
-				<dct:LinguisticSystem>eng</dct:LinguisticSystem>
+				<dct:LinguisticSystem>en</dct:LinguisticSystem>
 			</dct:language>
 			<dct:provenance><!-- Lineage -->
 				<dct:ProvenanceStatement>OPGC provenance</dct:ProvenanceStatement>
@@ -73,15 +73,15 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 				volcanology
 			</eposap:domain>
 			<eposap:subDomain> <!-- subDomain -->
-				geochemistry
+				TBD
 			</eposap:subDomain>
 			<dct:created>2017-06-26T10:00:00</dct:created> <!-- Data creation -->
 			<dct:subject><!-- Topic Category -->
 				EARTH SCIENCE
 			</dct:subject>
 			<cnt:characterEncoding>UTF-8</cnt:characterEncoding> <!-- Characterset -->
-			<dcat:contactPoint>OPGC_ID_05</dcat:contactPoint> <!--- Point of Contact -->
-			<eposap:responsibleParty>OPGC_ID_05</eposap:responsibleParty> <!---Responsible Party -->
+			<dcat:contactPoint>0000-0002-5066-5153</dcat:contactPoint> <!--- Point of Contact -->
+			<eposap:responsibleParty>0000-0002-5066-5153</eposap:responsibleParty> <!---Responsible Party -->
 			<rdf:comment>OpenstreetMap Resolution</rdf:comment><!-- Spatial Resolution -->
 			<adms:representationTechnique><!-- Spatial Rapresentation Tecnique -->
 				Point
@@ -94,13 +94,13 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 			<foaf:primaryTopic>Dynvolc Metadata</foaf:primaryTopic> <!-- Topic -->
 			<dct:modified>2017-06-26T12:00:00</dct:modified> <!-- Updated -->
 			<dct:language><!-- Language -->
-				<dct:LinguisticSystem>eng</dct:LinguisticSystem>
+				<dct:LinguisticSystem>en</dct:LinguisticSystem>
 			</dct:language>
 			<dct:title>Metadata 41</dct:title><!-- Standard Name -->
 			<dct:identifier>idvalue41</dct:identifier><!-- File identifier -->
 			<owl:versionInfo>0.1</owl:versionInfo><!-- Standard Version -->
 			<cnt:characterEncoding>UTF-8</cnt:characterEncoding><!-- Characterset -->
-			<dcat:contactPoint>OPGC_ID_05</dcat:contactPoint><!-- Point of contact -->
+			<dcat:contactPoint>0000-0002-5066-5153</dcat:contactPoint><!-- Point of contact -->
 			<dct:created>2016-10-31T12:00:00</dct:created> <!-- Created -->
 		</eposap:CatalogRecord>
 	</eposap:Catalog>
@@ -118,10 +118,10 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		</vcard:hasAddress>
 		<vcard:hasEmail>lucia.gurioli@uca.fr</vcard:hasEmail><!-- Email -->
 		<vcard:hasTelephone>+33 473 346 782</vcard:hasTelephone><!-- Phone -->
-		<dct:identifier>OPGC_ID_05</dct:identifier> <!-- Unique Identifier -->
-		<eposap:affiliation>ORGA_ID_05</eposap:affiliation> <!-- Organisation -->
+		<dct:identifier>0000-0002-5066-5153</dct:identifier> <!-- Unique Identifier -->
+		<eposap:affiliation>916450860</eposap:affiliation> <!-- Organisation -->
 		<dct:language><!-- Language for contact -->
-			<dct:LinguisticSystem>Eng</dct:LinguisticSystem>
+			<dct:LinguisticSystem>en</dct:LinguisticSystem>
 		</dct:language>
 		<schema:qualifications>PhD,HDR</schema:qualifications><!-- Qualification -->
 		<vcard:hasURL><!-- CV -->
@@ -141,10 +141,10 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		</vcard:hasAddress>
 		<vcard:hasEmail>p.labazuy@opgc.fr</vcard:hasEmail><!-- Email -->
 		<vcard:hasTelephone>+33 473 346 729</vcard:hasTelephone><!-- Phone -->
-		<dct:identifier>OPGC_ID_02</dct:identifier> <!-- Unique Identifier -->
-		<eposap:affiliation>ORGA_ID_05</eposap:affiliation> <!-- Organisation -->
+		<dct:identifier>0000-0002-4518-3328</dct:identifier> <!-- Unique Identifier -->
+		<eposap:affiliation>916450860</eposap:affiliation> <!-- Organisation -->
 		<dct:language><!-- Language for contact -->
-			<dct:LinguisticSystem>Eng</dct:LinguisticSystem>
+			<dct:LinguisticSystem>en</dct:LinguisticSystem>
 		</dct:language>
 		<schema:qualifications>PhD</schema:qualifications><!-- Qualification -->
 		<vcard:hasURL><!-- CV -->
@@ -164,10 +164,10 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		</vcard:hasAddress>
 		<vcard:hasEmail>p.bachelery@opgc.fr</vcard:hasEmail><!-- Email -->
 		<vcard:hasTelephone>+33 473 405 582</vcard:hasTelephone><!-- Phone -->
-		<dct:identifier>OPGC_ID_03</dct:identifier> <!-- Unique Identifier -->
-		<eposap:affiliation>ORGA_ID_05</eposap:affiliation> <!-- Organisation -->
+		<dct:identifier>0000-0002-0108-5486</dct:identifier> <!-- Unique Identifier -->
+		<eposap:affiliation>916450860</eposap:affiliation> <!-- Organisation -->
 		<dct:language><!-- Language for contact -->
-			<dct:LinguisticSystem>Eng</dct:LinguisticSystem>
+			<dct:LinguisticSystem>en</dct:LinguisticSystem>
 		</dct:language>
 		<schema:qualifications>PhD,HDR</schema:qualifications><!-- Qualification -->
 		<vcard:hasURL><!-- CV -->
@@ -187,10 +187,10 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		</vcard:hasAddress>
 		<vcard:hasEmail>dimuro@ipgp.fr</vcard:hasEmail><!-- Email -->
 		<vcard:hasTelephone>+33 262 275 012</vcard:hasTelephone><!-- Phone -->
-		<dct:identifier>IPGP_ID_01</dct:identifier> <!-- Unique Identifier -->
-		<eposap:affiliation>ORGA_ID_06</eposap:affiliation> <!-- Organisation -->
+		<dct:identifier>0000-0002-7635-1283</dct:identifier> <!-- Unique Identifier -->
+		<eposap:affiliation>999597417</eposap:affiliation> <!-- Organisation -->
 		<dct:language><!-- Language for contact -->
-			<dct:LinguisticSystem>Eng</dct:LinguisticSystem>
+			<dct:LinguisticSystem>en</dct:LinguisticSystem>
 		</dct:language>
 		<schema:qualifications>PhD,HDR</schema:qualifications><!-- Qualification -->
 		<vcard:hasURL><!-- CV -->
@@ -239,22 +239,22 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		<vcard:hasEmail>g.delcampo@opgc.univ-bpclermont.fr</vcard:hasEmail><!-- Email -->
 		<vcard:hasURL>http://opgc.fr</vcard:hasURL><!-- Website -->
 		<vcard:hasLogo>http://wwwobs.univ-bpclermont.fr/opgc/images/opgc_350t.gif</vcard:hasLogo><!-- Logo -->
-		<dct:identifier>ORGA_ID_05</dct:identifier><!-- Unique Identifier -->
-		<eposap:scientificContact>OPGC_ID_02</eposap:scientificContact><!-- Scientific
+		<dct:identifier>916450860</dct:identifier><!-- Unique Identifier -->
+		<eposap:scientificContact>0000-0002-4518-3328</eposap:scientificContact><!-- Scientific
 			Contact -->
 		<dct:spatial><!-- Spatial Coordinates -->
 			<dct:Location>
 				<!-- POINT(lon lat elevation) -->
-				<locn:geometry>POINT(3.111 45.761 0)</locn:geometry>
+				<locn:geometry>POINT(3.111 45.761)</locn:geometry>
 			</dct:Location>
 		</dct:spatial>
 		<dct:type><!-- Type -->
 			OUS - Observatory of Universe Sciences
 		</dct:type>
-		<eposap:legalContact>OPGC_ID_03</eposap:legalContact><!-- Legal Contact -->
-		<eposap:financialContact>OPGC_ID_03</eposap:financialContact><!-- Financial
+		<eposap:legalContact>0000-0002-0108-5486</eposap:legalContact><!-- Legal Contact -->
+		<eposap:financialContact>0000-0002-0108-5486</eposap:financialContact><!-- Financial
 			Contact -->
-		<eposap:isPartOf>ORGA_ID_02</eposap:isPartOf><!-- Is part of -->
+		<eposap:isPartOf>999997930</eposap:isPartOf><!-- Is part of -->
 		<!--<eposap:associatedProjects>projectID01</eposap:associatedProjects>-->
 			<!--Associated Project -->
 	</eposap:Organisation>
@@ -274,23 +274,23 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		</vcard:hasAddress>
 		<vcard:hasEmail>accueil@ipgp.fr</vcard:hasEmail><!-- Email -->
 		<vcard:hasURL>http://www.ipgp.fr/</vcard:hasURL><!-- Website -->
-		<vcard:hasLogo></vcard:hasLogo><!-- Logo -->
-		<dct:identifier>ORGA_ID_06</dct:identifier><!-- Unique Identifier -->
-		<eposap:scientificContact>IPGP_ID_01</eposap:scientificContact><!-- Scientific
+		<vcard:hasLogo>http://www.ipgp.fr/sites/all/themes/danland/logo.png</vcard:hasLogo><!-- Logo -->
+		<dct:identifier>999597417</dct:identifier><!-- Unique Identifier -->
+		<eposap:scientificContact>0000-0002-7635-1283</eposap:scientificContact><!-- Scientific
 			Contact -->
 		<dct:spatial><!-- Spatial Coordinates -->
 			<dct:Location>
 				<!-- POINT(lon lat elevation) -->
-				<locn:geometry>POINT(48.845034, 2.356752 0)</locn:geometry>
+				<locn:geometry>POINT(48.845034, 2.356752)</locn:geometry>
 			</dct:Location>
 		</dct:spatial>
 		<dct:type><!-- Type -->
 			OUS - Observatory of Universe Sciences
 		</dct:type>
-		<eposap:legalContact>IPGP_ID_01</eposap:legalContact><!-- Legal Contact -->
-		<eposap:financialContact>IPGP_ID_01</eposap:financialContact><!-- Financial
+		<eposap:legalContact>0000-0002-7635-1283</eposap:legalContact><!-- Legal Contact -->
+		<eposap:financialContact>0000-0002-7635-1283</eposap:financialContact><!-- Financial
 			Contact -->
-		<eposap:isPartOf>ORGA_ID_02</eposap:isPartOf><!-- Is part of -->
+		<eposap:isPartOf>999997930</eposap:isPartOf><!-- Is part of -->
 		<!--<eposap:associatedProjects>projectID01</eposap:associatedProjects>-->
 			<!--Associated Project -->
 	</eposap:Organisation>	
@@ -316,18 +316,18 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		</vcard:hasAddress>
 		<vcard:hasURL>http://cnrs.fr</vcard:hasURL><!-- Website -->
 		<vcard:hasLogo>http://www.cnrs.fr/fr/z-tools/newune/themes/CNRSTheme/images/logocnrs.png</vcard:hasLogo><!-- Logo -->
-		<dct:identifier>ORGA_ID_02</dct:identifier><!-- Unique Identifier -->
-		<eposap:scientificContact>OPGC_ID_03</eposap:scientificContact>		<dct:spatial><!-- Spatial Coordinates -->
+		<dct:identifier>999997930</dct:identifier><!-- Unique Identifier -->
+		<eposap:scientificContact>0000-0002-0108-5486</eposap:scientificContact>		<dct:spatial><!-- Spatial Coordinates -->
 			<dct:Location>
 				<!-- POINT(lon lat elevation) -->
-				<locn:geometry>POINT(2.264 48.847 0)</locn:geometry>
+				<locn:geometry>POINT(2.264 48.847)</locn:geometry>
 			</dct:Location>
 		</dct:spatial>
 		<dct:type>
 			Scientific and technical establishment 
 		</dct:type>
-		<eposap:legalContact>OPGC_ID_03</eposap:legalContact><!-- Legal Contact -->
-		<eposap:financialContact>OPGC_ID_03</eposap:financialContact><!-- Financial Contact -->
+		<eposap:legalContact>0000-0002-0108-5486</eposap:legalContact><!-- Legal Contact -->
+		<eposap:financialContact>0000-0002-0108-5486</eposap:financialContact><!-- Financial Contact -->
 	</eposap:Organisation>
 	
 
@@ -345,7 +345,7 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		-->
 		<dct:license>http://creativecommons.org/licenses/by-nc/4.0/</dct:license> <!-- Access and Use Restrictions -->
 		<foaf:page> <!-- URI -->
-			<foaf:primaryTopic>http://opgc.fr/vobs/rest2/req.php/dynvolc/epos_dcat_ap/41</foaf:primaryTopic>
+			<foaf:primaryTopic>http://opgc.fr/vobs/rest2/req.php/dynvolc/epos-dcat-ap/41</foaf:primaryTopic>
 		</foaf:page>
 		<dct:format><!-- distribution format, in case the service provides (also) access to binary data -->
 			<dct:MediaTypeOrExtent>xml</dct:MediaTypeOrExtent>
@@ -376,12 +376,12 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		Earthquake parameters, Velocity models, GNSS station velocities, InSAR, Meteorology, 
 		Variation of geomagnetic field, 3D/4D structural models, Analog models, Numerical models, 
 		Geochemical data, Borehole data, Rock sample properties) -->
-			Geochemical data
+			TBD
 		</eposap:subDomain>
 		
 		<!-- Keywords, annotation. Simple and free (web annotation ontology in the future) -->
 		<dcat:keyword>Laboratories, rocks</dcat:keyword> <!-- Keywords -->
-		<eposap:operation>download, visualise, etc</eposap:operation>
+		<eposap:operation>TBD</eposap:operation>
 		<dct:hasVersion>0.1</dct:hasVersion>
 
 		<!-- List of Parameters:
@@ -412,9 +412,8 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		</eposap:parameter>
 		<!-- The document is meant to be human readable (e.g. PDF, doc, and so on). 
 			This will help a user who, for instance, does not understand something from the hints/label of the parameters. -->
-		<schema:documentation>URL pointing to the specification</schema:documentation>
-		<dcat:contactPoint>OPGC_ID_05</dcat:contactPoint> <!-- internal link to contact point (vcard:Individual) described in the same file in <eposap:Person> -->
-		<eposap:publisher>ORGA_ID_05</eposap:publisher> <!-- internal link to responsibleParty (vcard:Organisation) described in the same file in <eposap:Organisation> -->
+		<dcat:contactPoint>0000-0002-5066-5153</dcat:contactPoint> <!-- internal link to contact point (vcard:Individual) described in the same file in <eposap:Person> -->
+		<eposap:publisher>916450860</eposap:publisher> <!-- internal link to responsibleParty (vcard:Organisation) described in the same file in <eposap:Organisation> -->
 		<dct:spatial> <!-- Geographic location/spatial extent /bounding box -->
 			<dct:Location>
 				<!-- POLYGON(lon1 lat1, lon2 lat2,...) -->
@@ -436,8 +435,8 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 	<eposap:Publication>
 	   <dct:identifier>doi_10.1007_s00445-015-0935-x</dct:identifier><!--10.1007/s00445-015-0935-x-->
 	  <dct:title>MeMoVolc consensual document: a review of cross-disciplinary approaches to characterizing small explosive magmatic eruptions</dct:title>
-	  <eposap:authors>OPGC_ID_05</eposap:authors>
-	  <eposap:publisher>OPGC_ID_05</eposap:publisher><!--Bulletin of Volcanology-->
+	  <eposap:authors>0000-0002-5066-5153</eposap:authors>
+	  <eposap:publisher>0000-0002-5066-5153</eposap:publisher><!--Bulletin of Volcanology-->
 	  <dct:abstract>A workshop entitled “Tracking and understanding volcanic emissions through cross-disciplinary integration: A textural working group.” was held at the Université Blaise Pascal (Clermont-Ferrand, France) on the 6-7 November 2012. This workshop was supported by the European Science Foundation (ESF). The main objective of the workshop was to establish an initial advisory group to begin to define measurements, methods, formats and standards to be applied in the integration of geophysical, physical and textural data collected during volcanic eruptions. This would homogenize procedures to be applied and integrated during both past and ongoing events. The workshop comprised a total of 35 scientists from six countries (France, Italy, Great Britain, Germany, Switzerland and Iceland). The four main aims were to discuss and define: (1) Standards, precision and measurement protocols for textural analysis (2) Identification of textural, field deposit, chemistry and geophysical parameters that can best be measured and combined (3) The best delivery formats so that data can be shared between, and easily used by different groups (4) Multi-disciplinary sampling and measurement routines currently used, and measurement standards applied, by each community. The group agreed that community-wide, cross-disciplinary integration, centered on defining those measurements and formats that can be best combined, is an attainable and key global focus. Consequently, we prepared this paper to present our initial conclusions and recommendations, along with a review of the current state of the art in this field that supported our discussions.</dct:abstract>
 	  <dct:issued>2015-04-16T12:00:00</dct:issued>
 	  <schema:issn>0258-8900</schema:issn>
@@ -445,7 +444,7 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 	  <schema:volumeNumber>49</schema:volumeNumber>
 	  <schema:numberOfPages>33</schema:numberOfPages>
 	  <schema:keywords>MeMoVolc, European Science Foundation, Small explosive magmatic eruptions, Texture</schema:keywords>
-	  <eposap:contributors>OPGC_ID_05</eposap:contributors> <!--, OPGC_ID_03 -->
+	  <eposap:contributors>0000-0002-5066-5153</eposap:contributors> <!--, 0000-0002-0108-5486 -->
 	  <dct:accessRights>
 	    <dct:RightsStatement>Pay-per-view Access</dct:RightsStatement>
 	  </dct:accessRights>
@@ -457,8 +456,8 @@ xmlns:adms="http://www.w3.org/ns/adms#"
   	<eposap:Publication>
 	   <dct:identifier>doi_NONE</dct:identifier>
 	  <dct:title>Les apports d’une vision intégrée des données volcanologiques (DynVolc) p299-p335</dct:title>
-	  <eposap:authors>OPGC_ID_05</eposap:authors>
-	  <eposap:publisher>OPGC_ID_05</eposap:publisher><!--Revue d'Auvergne-->
+	  <eposap:authors>0000-0002-5066-5153</eposap:authors>
+	  <eposap:publisher>0000-0002-5066-5153</eposap:publisher><!--Revue d'Auvergne-->
 	  <dct:abstract>DynVolc (Dynamics of Volcanoes) is a new observation system developed and carried by the OPGC (Observatory of  Philosophy of the Globe of Clermont-Ferrand) within the framework of the SNOV (National Volcanology Observation Service). This observation system proposes the integration of textural, petro-geochemical and geophysical data in order to understand the complex mechanisms determining magma ascension, fragmentation and eruption. This multidisciplinary approach is now indispensable in monitoring active volcanoes and fundamental for understanding and forecasting volcanic eruptions. Within this system, significant investiments have been made in the development of innovative strategies for  sampling explosive and effusive products during ongoing eruptions, as well as routine analysis of volcanic emissions products. During volcanic crises at Piton de La Fournaise (Reunion, France), this observation system provides textural and chemical data from pyroclastic and lavic samples to monitor their evolution during the volcanic crisis. The samples are sent systematically by the OVPF and studied and analyzed at LMV (Laboratoire Magmas et Volcans) by a group of experts in the textural, petrographical, geochemical and geophysical measurements.</dct:abstract>
 	  <dct:issued>2016-01-01T12:00:00</dct:issued>
 	  <schema:issn>1269-8946</schema:issn>
@@ -466,7 +465,7 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 	  <schema:volumeNumber>1</schema:volumeNumber>
 	  <schema:numberOfPages>36</schema:numberOfPages>
 	  <schema:keywords>OPGC,DYNVOLC</schema:keywords>
-	  <eposap:contributors>OPGC_ID_05</eposap:contributors> <!--, OPGC_ID_03 -->
+	  <eposap:contributors>0000-0002-5066-5153</eposap:contributors> <!--, 0000-0002-0108-5486 -->
 	  <dct:accessRights>
 	    <dct:RightsStatement>Pay-per-view Access</dct:RightsStatement>
 	  </dct:accessRights>
@@ -499,7 +498,7 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 	    <dct:title>Platform instruments</dct:title> <!-- InstrumentName  -->
 	    <eposap:relatedTo>FACI_ID_02</eposap:relatedTo> <!-- facility  -->
   		<eposap:isPartOf>EQUI_ID_01</eposap:isPartOf> <!-- equipment  -->
-  		<dcat:contactPoint>OPGC_ID_05</dcat:contactPoint> <!-- person -->
+  		<dcat:contactPoint>0000-0002-5066-5153</dcat:contactPoint> <!-- person -->
   		<eposap:owner>FACI_ID_02</eposap:owner> <!-- Organization  -->
 	    <dct:temporal>
 	      <dct:PeriodOfTime>
@@ -521,7 +520,7 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 	    <dct:spatial> <!-- location -->
 	      <dct:Location>
 		<!-- POINT(lon lat elevation) -->
-	        <locn:geometry>POINT(3.111 45.761 0)</locn:geometry>
+	        <locn:geometry>POINT(3.111 45.761)</locn:geometry>
 	      </dct:Location>
 	    </dct:spatial>
   </eposap:Equipment>
@@ -539,9 +538,9 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		    </vcard:Address>
 	  	</vcard:hasAddress>
 	    <dct:description>LMV analytical and technical ressources : Textural lab (Micrometric Geopyc 1360, Micrometric AccuPyc II 1340, Permeameter, ASHER, Malvern Morphologi® G3) Sawing-milling-coring, Thin section preparation, SEM (JEOL JSM-5910LV), Probe(SX-100 CAMECA) and ICP-AES.</dct:description>
-	    <eposap:owner>ORGA_ID_05</eposap:owner><!-- organisation : OPGC -->
-	   	<dcat:contactPoint>OPGC_ID_05</dcat:contactPoint><!-- person -->
-  		<eposap:facilityManager>OPGC_ID_05</eposap:facilityManager><!-- person -->
+	    <eposap:owner>916450860</eposap:owner><!-- organisation : OPGC -->
+	   	<dcat:contactPoint>0000-0002-5066-5153</dcat:contactPoint><!-- person -->
+  		<eposap:facilityManager>0000-0002-5066-5153</eposap:facilityManager><!-- person -->
 	    <dct:type> <!-- type -->
 	      CNRS/IRD/UCA Laboratory
 	    </dct:type>
@@ -565,9 +564,9 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		    </vcard:Address>
 	  	</vcard:hasAddress>
 	    <dct:description>Observatoire Volcanologique du Piton de la Fournaise</dct:description>
-	    <eposap:owner>ORGA_ID_06</eposap:owner><!-- organisation : IPGP -->
-	   	<dcat:contactPoint>IPGP_ID_01</dcat:contactPoint><!-- person -->
-  		<eposap:facilityManager>IPGP_ID_01</eposap:facilityManager><!-- person -->
+	    <eposap:owner>999597417</eposap:owner><!-- organisation : IPGP -->
+	   	<dcat:contactPoint>0000-0002-7635-1283</dcat:contactPoint><!-- person -->
+  		<eposap:facilityManager>0000-0002-7635-1283</eposap:facilityManager><!-- person -->
 	    <dct:type> <!-- type -->
 	      CNRS/USPC Institute
 	    </dct:type>

--- a/examples/WP11/WP11-DDSS-036_GAZVOLC.xml
+++ b/examples/WP11/WP11-DDSS-036_GAZVOLC.xml
@@ -24,7 +24,7 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 			<dct:issued>2015-10-01T09:00:00</dct:issued><!-- Date of Publication -->
 			<dct:modified>2017-06-26T11:00:00</dct:modified><!-- Date of Revision -->
 			<dct:language><!-- Language -->
-				<dct:LinguisticSystem>eng</dct:LinguisticSystem>
+				<dct:LinguisticSystem>en</dct:LinguisticSystem>
 			</dct:language>
 			<dct:provenance><!-- Lineage -->
 				<dct:ProvenanceStatement>OPGC provenance</dct:ProvenanceStatement>
@@ -73,15 +73,15 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 				volcanology
 			</eposap:domain>
 			<eposap:subDomain> <!-- subDomain -->
-				geochemistry
+				TDB
 			</eposap:subDomain>
 			<dct:created>2017-06-26T10:00:00</dct:created> <!-- Data creation -->
 			<dct:subject><!-- Topic Category -->
 				EARTH SCIENCE
 			</dct:subject>
 			<cnt:characterEncoding>UTF-8</cnt:characterEncoding> <!-- Characterset -->
-			<dcat:contactPoint>OPGC_ID_04</dcat:contactPoint> <!--- Point of Contact -->
-			<eposap:responsibleParty>OPGC_ID_04</eposap:responsibleParty> <!---Responsible Party -->
+			<dcat:contactPoint>0000-0002-8485-0154</dcat:contactPoint> <!--- Point of Contact -->
+			<eposap:responsibleParty>0000-0002-8485-0154</eposap:responsibleParty> <!---Responsible Party -->
 			<rdf:comment>OpenstreetMap Resolution</rdf:comment><!-- Spatial Resolution -->
 			<adms:representationTechnique><!-- Spatial Rapresentation Tecnique -->
 				Point
@@ -94,13 +94,13 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 			<foaf:primaryTopic>GAZVOLC Metadata</foaf:primaryTopic> <!-- Topic -->
 			<dct:modified>2017-06-26T12:00:00</dct:modified> <!-- Updated -->
 			<dct:language><!-- Language -->
-				<dct:LinguisticSystem>eng</dct:LinguisticSystem>
+				<dct:LinguisticSystem>en</dct:LinguisticSystem>
 			</dct:language>
 			<dct:title>Metadata 41</dct:title><!-- Standard Name -->
 			<dct:identifier>idvalue41</dct:identifier><!-- File identifier -->
 			<owl:versionInfo>0.1</owl:versionInfo><!-- Standard Version -->
 			<cnt:characterEncoding>UTF-8</cnt:characterEncoding><!-- Characterset -->
-			<dcat:contactPoint>OPGC_ID_04</dcat:contactPoint><!-- Point of contact -->
+			<dcat:contactPoint>0000-0002-8485-0154</dcat:contactPoint><!-- Point of contact -->
 			<dct:created>2016-10-31T12:00:00</dct:created> <!-- Created -->
 		</eposap:CatalogRecord>
 	</eposap:Catalog>
@@ -118,10 +118,10 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		</vcard:hasAddress>
 		<vcard:hasEmail>s.moune@opgc.fr</vcard:hasEmail><!-- Email -->
 		<vcard:hasTelephone>+33 473 346 745</vcard:hasTelephone><!-- Phone -->
-		<dct:identifier>OPGC_ID_04</dct:identifier> <!-- Unique Identifier -->
-		<eposap:affiliation>ORGA_ID_05</eposap:affiliation> <!-- Organisation -->
+		<dct:identifier>0000-0002-8485-0154</dct:identifier> <!-- Unique Identifier -->
+		<eposap:affiliation>916450860</eposap:affiliation> <!-- Organisation -->
 		<dct:language><!-- Language for contact -->
-			<dct:LinguisticSystem>Eng</dct:LinguisticSystem>
+			<dct:LinguisticSystem>en</dct:LinguisticSystem>
 		</dct:language>
 		<schema:qualifications>PhD</schema:qualifications><!-- Qualification -->
 		<vcard:hasURL><!-- CV -->
@@ -141,10 +141,10 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		</vcard:hasAddress>
 		<vcard:hasEmail>p.labazuy@opgc.fr</vcard:hasEmail><!-- Email -->
 		<vcard:hasTelephone>+33 473 346 729</vcard:hasTelephone><!-- Phone -->
-		<dct:identifier>OPGC_ID_02</dct:identifier> <!-- Unique Identifier -->
-		<eposap:affiliation>ORGA_ID_05</eposap:affiliation> <!-- Organisation -->
+		<dct:identifier>0000-0002-4518-3328</dct:identifier> <!-- Unique Identifier -->
+		<eposap:affiliation>916450860</eposap:affiliation> <!-- Organisation -->
 		<dct:language><!-- Language for contact -->
-			<dct:LinguisticSystem>Eng</dct:LinguisticSystem>
+			<dct:LinguisticSystem>en</dct:LinguisticSystem>
 		</dct:language>
 		<schema:qualifications>PhD</schema:qualifications><!-- Qualification -->
 		<vcard:hasURL><!-- CV -->
@@ -164,10 +164,10 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		</vcard:hasAddress>
 		<vcard:hasEmail>p.bachelery@opgc.fr</vcard:hasEmail><!-- Email -->
 		<vcard:hasTelephone>+33 473 405 582</vcard:hasTelephone><!-- Phone -->
-		<dct:identifier>OPGC_ID_03</dct:identifier> <!-- Unique Identifier -->
-		<eposap:affiliation>ORGA_ID_05</eposap:affiliation> <!-- Organisation -->
+		<dct:identifier>0000-0002-0108-5486</dct:identifier> <!-- Unique Identifier -->
+		<eposap:affiliation>916450860</eposap:affiliation> <!-- Organisation -->
 		<dct:language><!-- Language for contact -->
-			<dct:LinguisticSystem>Eng</dct:LinguisticSystem>
+			<dct:LinguisticSystem>en</dct:LinguisticSystem>
 		</dct:language>
 		<schema:qualifications>PhD,HDR</schema:qualifications><!-- Qualification -->
 		<vcard:hasURL><!-- CV -->
@@ -187,10 +187,10 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		</vcard:hasAddress>
 		<vcard:hasEmail>dimuro@ipgp.fr</vcard:hasEmail><!-- Email -->
 		<vcard:hasTelephone>+33 262 275 012</vcard:hasTelephone><!-- Phone -->
-		<dct:identifier>IPGP_ID_01</dct:identifier> <!-- Unique Identifier -->
-		<eposap:affiliation>ORGA_ID_06</eposap:affiliation> <!-- Organisation -->
+		<dct:identifier>0000-0002-7635-1283</dct:identifier> <!-- Unique Identifier -->
+		<eposap:affiliation>999597417</eposap:affiliation> <!-- Organisation -->
 		<dct:language><!-- Language for contact -->
-			<dct:LinguisticSystem>Eng</dct:LinguisticSystem>
+			<dct:LinguisticSystem>en</dct:LinguisticSystem>
 		</dct:language>
 		<schema:qualifications>PhD,HDR</schema:qualifications><!-- Qualification -->
 		<vcard:hasURL><!-- CV -->
@@ -211,7 +211,7 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		<vcard:hasEmail>contact@cnrs.fr</vcard:hasEmail>
 		<vcard:hasTelephone>+33 144 964 000</vcard:hasTelephone>
 		<dct:identifier>CNRS_ID_00</dct:identifier>
-		<eposap:affiliation>NONE</eposap:affiliation> 
+		<eposap:affiliation>NONE</eposap:affiliation>
 		<dct:language>
 			<dct:LinguisticSystem>Fr</dct:LinguisticSystem>
 		</dct:language>
@@ -239,22 +239,22 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		<vcard:hasEmail>g.delcampo@opgc.univ-bpclermont.fr</vcard:hasEmail><!-- Email -->
 		<vcard:hasURL>http://opgc.fr</vcard:hasURL><!-- Website -->
 		<vcard:hasLogo>http://wwwobs.univ-bpclermont.fr/opgc/images/opgc_350t.gif</vcard:hasLogo><!-- Logo -->
-		<dct:identifier>ORGA_ID_05</dct:identifier><!-- Unique Identifier -->
-		<eposap:scientificContact>OPGC_ID_02</eposap:scientificContact><!-- Scientific
+		<dct:identifier>916450860</dct:identifier><!-- Unique Identifier -->
+		<eposap:scientificContact>0000-0002-4518-3328</eposap:scientificContact><!-- Scientific
 			Contact -->
 		<dct:spatial><!-- Spatial Coordinates -->
 			<dct:Location>
 				<!-- POINT(lon lat elevation) -->
-				<locn:geometry>POINT(3.111 45.761 0)</locn:geometry>
+				<locn:geometry>POINT(3.111 45.761)</locn:geometry>
 			</dct:Location>
 		</dct:spatial>
 		<dct:type><!-- Type -->
 			OUS - Observatory of Universe Sciences
 		</dct:type>
-		<eposap:legalContact>OPGC_ID_03</eposap:legalContact><!-- Legal Contact -->
-		<eposap:financialContact>OPGC_ID_03</eposap:financialContact><!-- Financial
+		<eposap:legalContact>0000-0002-0108-5486</eposap:legalContact><!-- Legal Contact -->
+		<eposap:financialContact>0000-0002-0108-5486</eposap:financialContact><!-- Financial
 			Contact -->
-		<eposap:isPartOf>ORGA_ID_02</eposap:isPartOf><!-- Is part of -->
+		<eposap:isPartOf>999997930</eposap:isPartOf><!-- Is part of -->
 		<!--<eposap:associatedProjects>projectID01</eposap:associatedProjects>-->
 			<!--Associated Project -->
 	</eposap:Organisation>
@@ -275,31 +275,31 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		<vcard:hasEmail>accueil@ipgp.fr</vcard:hasEmail><!-- Email -->
 		<vcard:hasURL>http://www.ipgp.fr/</vcard:hasURL><!-- Website -->
 		<vcard:hasLogo>http://www.ipgp.fr/sites/all/themes/danland/logo.png</vcard:hasLogo><!-- Logo -->
-		<dct:identifier>ORGA_ID_06</dct:identifier><!-- Unique Identifier -->
-		<eposap:scientificContact>IPGP_ID_01</eposap:scientificContact><!-- Scientific
+		<dct:identifier>999597417</dct:identifier><!-- Unique Identifier -->
+		<eposap:scientificContact>0000-0002-7635-1283</eposap:scientificContact><!-- Scientific
 			Contact -->
 		<dct:spatial><!-- Spatial Coordinates -->
 			<dct:Location>
 				<!-- POINT(lon lat elevation) -->
-				<locn:geometry>POINT(48.845034, 2.356752 0)</locn:geometry>
+				<locn:geometry>POINT(48.845034, 2.356752)</locn:geometry>
 			</dct:Location>
 		</dct:spatial>
 		<dct:type><!-- Type -->
 			OUS - Observatory of Universe Sciences
 		</dct:type>
-		<eposap:legalContact>IPGP_ID_01</eposap:legalContact><!-- Legal Contact -->
-		<eposap:financialContact>IPGP_ID_01</eposap:financialContact><!-- Financial
+		<eposap:legalContact>0000-0002-7635-1283</eposap:legalContact><!-- Legal Contact -->
+		<eposap:financialContact>0000-0002-7635-1283</eposap:financialContact><!-- Financial
 			Contact -->
-		<eposap:isPartOf>ORGA_ID_02</eposap:isPartOf><!-- Is part of -->
+		<eposap:isPartOf>999997930</eposap:isPartOf><!-- Is part of -->
 		<!--<eposap:associatedProjects>projectID01</eposap:associatedProjects>-->
 			<!--Associated Project -->
-	</eposap:Organisation>	
-	
-	
-	<!-- EPOS Project 
+	</eposap:Organisation>
+
+
+	<!-- EPOS Project
 	<eposap:Project>
 		<dct:identifier>projectID01</dct:identifier>
-		<dct:title>Project name</dct:title> 
+		<dct:title>Project name</dct:title>
 		<dct:description>Some description</dct:description>
 	</eposap:Project>-->
 
@@ -316,20 +316,20 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		</vcard:hasAddress>
 		<vcard:hasURL>http://cnrs.fr</vcard:hasURL><!-- Website -->
 		<vcard:hasLogo>http://www.cnrs.fr/fr/z-tools/newune/themes/CNRSTheme/images/logocnrs.png</vcard:hasLogo><!-- Logo -->
-		<dct:identifier>ORGA_ID_02</dct:identifier><!-- Unique Identifier -->
-		<eposap:scientificContact>OPGC_ID_03</eposap:scientificContact>		<dct:spatial><!-- Spatial Coordinates -->
+		<dct:identifier>999997930</dct:identifier><!-- Unique Identifier -->
+		<eposap:scientificContact>0000-0002-0108-5486</eposap:scientificContact>		<dct:spatial><!-- Spatial Coordinates -->
 			<dct:Location>
 				<!-- POINT(lon lat elevation) -->
-				<locn:geometry>POINT(2.264 48.847 0)</locn:geometry>
+				<locn:geometry>POINT(2.264 48.847)</locn:geometry>
 			</dct:Location>
 		</dct:spatial>
 		<dct:type>
-			Scientific and technical establishment 
+			Scientific and technical establishment
 		</dct:type>
-		<eposap:legalContact>OPGC_ID_03</eposap:legalContact><!-- Legal Contact -->
-		<eposap:financialContact>OPGC_ID_03</eposap:financialContact><!-- Financial Contact -->
+		<eposap:legalContact>0000-0002-0108-5486</eposap:legalContact><!-- Legal Contact -->
+		<eposap:financialContact>0000-0002-0108-5486</eposap:financialContact><!-- Financial Contact -->
 	</eposap:Organisation>
-	
+
 
 	<!-- EPOS WebService -->
 	<eposap:WebService>
@@ -347,7 +347,7 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		-->
 		<dct:license>http://creativecommons.org/licenses/by-nc/4.0/</dct:license> <!-- Access and Use Restrictions -->
 		<foaf:page> <!-- URI -->
-			<foaf:primaryTopic>http://opgc.fr/vobs/rest2/req.php/gazvolc/epos_dcat_ap/41</foaf:primaryTopic>
+			<foaf:primaryTopic>http://opgc.fr/vobs/rest2/req.php/gazvolc/epos-dcat-ap/41</foaf:primaryTopic>
 		</foaf:page>
 		<dct:format><!-- distribution format, in case the service provides (also) access to binary data -->
 			<dct:MediaTypeOrExtent>xml</dct:MediaTypeOrExtent>
@@ -370,20 +370,20 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 		<dct:conformsTo>EPSG:4326</dct:conformsTo> <!-- Spatial Reference System -->
 		<dct:identifier>opgc.fr</dct:identifier> <!-- Unique Resource Identifier: this is the entry point of the service -->
 		<dct:created>2017-06-27T12:00:00</dct:created> <!-- date of creation -->
-		<eposap:domain> <!-- This property refers to the domain of resource (e.g. Seismology, Geodesy, 
+		<eposap:domain> <!-- This property refers to the domain of resource (e.g. Seismology, Geodesy,
 		Satellite data, Geomagnetic data, Geology, Geohazards, Georesources, Transnational access) -->
 			Volcanology
 		</eposap:domain>
-		<eposap:subDomain> <!-- This property refers to the subdomain of resource (e.g. 
-		Earthquake parameters, Velocity models, GNSS station velocities, InSAR, Meteorology, 
-		Variation of geomagnetic field, 3D/4D structural models, Analog models, Numerical models, 
+		<eposap:subDomain> <!-- This property refers to the subdomain of resource (e.g.
+		Earthquake parameters, Velocity models, GNSS station velocities, InSAR, Meteorology,
+		Variation of geomagnetic field, 3D/4D structural models, Analog models, Numerical models,
 		Geochemical data, Borehole data, Rock sample properties) -->
-			Geochemical data
+			TBD
 		</eposap:subDomain>
-		
+
 		<!-- Keywords, annotation. Simple and free (web annotation ontology in the future) -->
 		<dcat:keyword>Laboratories, Rocks, Gas, Chemical Data set, Volcanology</dcat:keyword> <!-- Keywords -->
-		<eposap:operation>download, visualise, etc</eposap:operation>
+		<eposap:operation>TBD</eposap:operation>
 		<dct:hasVersion>0.1</dct:hasVersion>
 
 		<!-- List of Parameters:
@@ -398,7 +398,7 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 				integer
 			</dct:type>
 			<!-- These properties refer to range value of the parameter -->
-			<schema:minValue>1</schema:minValue> 
+			<schema:minValue>1</schema:minValue>
 			<schema:maxValue>50</schema:maxValue>
 		</eposap:parameter>
 		<eposap:parameter>
@@ -412,11 +412,8 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 			<http:paramValue>gazvolc</http:paramValue>
 			<owl:versionInfo>1.0</owl:versionInfo> <!-- version of parameter -->
 		</eposap:parameter>
-		<!-- The document is meant to be human readable (e.g. PDF, doc, and so on). 
-			This will help a user who, for instance, does not understand something from the hints/label of the parameters. -->
-		<schema:documentation>URL pointing to the specification</schema:documentation>
-		<dcat:contactPoint>OPGC_ID_04</dcat:contactPoint> <!-- internal link to contact point (vcard:Individual) described in the same file in <eposap:Person> -->
-		<eposap:publisher>ORGA_ID_05</eposap:publisher> <!-- internal link to responsibleParty (vcard:Organisation) described in the same file in <eposap:Organisation> -->
+		<dcat:contactPoint>0000-0002-8485-0154</dcat:contactPoint> <!-- internal link to contact point (vcard:Individual) described in the same file in <eposap:Person> -->
+		<eposap:publisher>916450860</eposap:publisher> <!-- internal link to responsibleParty (vcard:Organisation) described in the same file in <eposap:Organisation> -->
 		<dct:spatial> <!-- Geographic location/spatial extent /bounding box -->
 			<dct:Location>
 				<!-- POLYGON(lon1 lat1, lon2 lat2,...) -->
@@ -433,13 +430,13 @@ xmlns:adms="http://www.w3.org/ns/adms#"
 			</dct:PeriodOfTime>
 		</dct:temporal>
 	</eposap:WebService>
-	
+
 	<!--  EPOS Publication -->
 	<eposap:Publication>
 	   <dct:identifier>doi_None_REVUE_AUVERGNE</dct:identifier><!--10.1007/s00445-015-0935-x-->
 	  <dct:title>"GAZ VOLCaniques: outil primordial pour suivre l’activité des volcans" in "Des volcans aux nuages - L'Observatoire de Physique du Globe de Clermont-Ferrand" pp. 371-387</dct:title>
-	  <eposap:authors>OPGC_ID_04</eposap:authors>
-	  <eposap:publisher>ORGA_ID_05</eposap:publisher><!--Bulletin of Volcanology-->
+	  <eposap:authors>0000-0002-8485-0154</eposap:authors>
+	  <eposap:publisher>916450860</eposap:publisher><!--Bulletin of Volcanology-->
 	  <dct:abstract>l’abstract est: GAZVOLC is an observation system within France’s National Service
 for Volcanological Observation (SNOV). The study of magmatic degassing and of
 hydrothermal systems is of the utmost importance in furthering our understanding of
@@ -460,7 +457,7 @@ eruption.</dct:abstract>
 	  <schema:volumeNumber>1</schema:volumeNumber>
 	  <schema:numberOfPages>16</schema:numberOfPages>
 	  <schema:keywords>OPGC, Gazvolc, Chemical Data set, melt inclusion, volatile elements, major elements, trace elements, groundmass, host minerals</schema:keywords>
-	  <eposap:contributors>ORGA_ID_05</eposap:contributors> <!--, OPGC_ID_03 -->
+	  <eposap:contributors>916450860</eposap:contributors> <!--, 0000-0002-0108-5486 -->
 	  <dct:accessRights>
 	    <dct:RightsStatement>Pay-per-view Access</dct:RightsStatement>
 	  </dct:accessRights>
@@ -469,7 +466,7 @@ eruption.</dct:abstract>
 	  </dct:format>
   </eposap:Publication>
 
-	<!--  EPOS Service 
+	<!--  EPOS Service
 	<eposap:Service>
 		<dct:identifier>serviceID01</dct:identifier>
 	  <schema:name>name of service</schema:name>
@@ -493,7 +490,7 @@ eruption.</dct:abstract>
 	    <dct:title>Platform instruments</dct:title> <!-- InstrumentName  -->
 	    <eposap:relatedTo>FACI_ID_02</eposap:relatedTo> <!-- facility  -->
   		<eposap:isPartOf>EQUI_ID_01</eposap:isPartOf> <!-- equipment  -->
-  		<dcat:contactPoint>OPGC_ID_04</dcat:contactPoint> <!-- person -->
+  		<dcat:contactPoint>0000-0002-8485-0154</dcat:contactPoint> <!-- person -->
   		<eposap:owner>FACI_ID_02</eposap:owner> <!-- Organization  -->
 	    <dct:temporal>
 	      <dct:PeriodOfTime>
@@ -515,7 +512,7 @@ eruption.</dct:abstract>
 	    <dct:spatial> <!-- location -->
 	      <dct:Location>
 		<!-- POINT(lon lat elevation) -->
-	        <locn:geometry>POINT(3.111 45.761 0)</locn:geometry>
+	        <locn:geometry>POINT(3.111 45.761)</locn:geometry>
 	      </dct:Location>
 	    </dct:spatial>
   </eposap:Equipment>
@@ -533,9 +530,9 @@ eruption.</dct:abstract>
 		    </vcard:Address>
 	  	</vcard:hasAddress>
 	    <dct:description>LMV analytical and technical ressources : Textural lab (Micrometric Geopyc 1360, Micrometric AccuPyc II 1340, Permeameter, ASHER, Malvern Morphologi® G3) Sawing-milling-coring, Thin section preparation, SEM (JEOL JSM-5910LV), Probe(SX-100 CAMECA) and ICP-AES.</dct:description>
-	    <eposap:owner>ORGA_ID_05</eposap:owner><!-- organisation : OPGC -->
-	   	<dcat:contactPoint>OPGC_ID_04</dcat:contactPoint><!-- person -->
-  		<eposap:facilityManager>OPGC_ID_04</eposap:facilityManager><!-- person -->
+	    <eposap:owner>916450860</eposap:owner><!-- organisation : OPGC -->
+	   	<dcat:contactPoint>0000-0002-8485-0154</dcat:contactPoint><!-- person -->
+  		<eposap:facilityManager>0000-0002-8485-0154</eposap:facilityManager><!-- person -->
 	    <dct:type> <!-- type -->
 	      CNRS/IRD/UCA Laboratory
 	    </dct:type>
@@ -559,7 +556,7 @@ eruption.</dct:abstract>
 		    </vcard:Address>
 	  	</vcard:hasAddress>
 	    <dct:description>Observatoire Volcanologique du Piton de la Fournaise</dct:description>
-	    <eposap:owner>ORGA_ID_06</eposap:owner><!-- organisation : IPGP -->
+	    <eposap:owner>999597417</eposap:owner><!-- organisation : IPGP -->
 	   	<dcat:contactPoint>IPGP_ID_01</dcat:contactPoint><!-- person -->
   		<eposap:facilityManager>IPGP_ID_01</eposap:facilityManager><!-- person -->
 	    <dct:type> <!-- type -->

--- a/examples/WP11/WP11-DDSS-049_HOTVOLC_Lava_products.xml
+++ b/examples/WP11/WP11-DDSS-049_HOTVOLC_Lava_products.xml
@@ -21,7 +21,7 @@
       <dct:modified>2017-06-20T11:43:47Z</dct:modified>
       <!--Language-->
       <dct:language>
-        <dct:LinguisticSystem>English</dct:LinguisticSystem>
+        <dct:LinguisticSystem>en</dct:LinguisticSystem>
       </dct:language>
       <!--Lineage-->
       <dct:provenance>
@@ -45,7 +45,7 @@
       <dct:spatial>
         <dct:Location>
           <!--POINT(lon lat elevation)-->
-          <locn:geometry>POINT(15.004 37.734 0)</locn:geometry>
+          <locn:geometry>POINT(15.004 37.734)</locn:geometry>
         </dct:Location>
       </dct:spatial>
       <!--Temporal extent-->
@@ -76,7 +76,7 @@
       <!--Domain-->
       <eposap:domain>Volcanology</eposap:domain>
       <!--subDomain-->
-      <eposap:subDomain>Thermal infrared imagery from geostationary satellites</eposap:subDomain>
+      <eposap:subDomain>TBD</eposap:subDomain>
       <!--Data creation-->
       <dct:created>2016-05-26T08:00:00Z</dct:created>
       <!--Topic category-->
@@ -84,9 +84,9 @@
       <!--Characterset-->
       <cnt:characterEncoding>UTF-8</cnt:characterEncoding>
       <!--Point of contact-->
-      <dcat:contactPoint>OPGC_ID_01</dcat:contactPoint>
+      <dcat:contactPoint>0000-0001-8720-7300</dcat:contactPoint>
       <!--Responsible party-->
-      <eposap:responsibleParty>OPGC_ID_01</eposap:responsibleParty>
+      <eposap:responsibleParty>0000-0001-8720-7300</eposap:responsibleParty>
       <!--Spatial Resolution-->
       <rdf:comment/>
       <!--Spatial Representation Technique-->
@@ -101,7 +101,7 @@
       <dct:modified>2017-06-20T11:43:47Z</dct:modified>
       <dct:language>
         <!--Language-->
-        <dct:LinguisticSystem>English</dct:LinguisticSystem>
+        <dct:LinguisticSystem>en</dct:LinguisticSystem>
       </dct:language>
       <!--Standard Name-->
       <dct:title>20160526080000_20160526094500_Etna_Volume.csv Metadata</dct:title>
@@ -112,7 +112,7 @@
       <!--Characterset-->
       <cnt:characterEncoding>UTF-8</cnt:characterEncoding>
       <!--Point of contact-->
-      <dcat:contactPoint>OPGC_ID_01</dcat:contactPoint>
+      <dcat:contactPoint>0000-0001-8720-7300</dcat:contactPoint>
       <!--Created-->
       <dct:created>2017-06-20T11:04:35Z</dct:created>
     </eposap:CatalogRecord>
@@ -137,7 +137,7 @@
       <dct:modified>2017-06-20T11:43:47Z</dct:modified>
       <!--Language-->
       <dct:language>
-        <dct:LinguisticSystem>English</dct:LinguisticSystem>
+        <dct:LinguisticSystem>en</dct:LinguisticSystem>
       </dct:language>
       <!--Lineage-->
       <dct:provenance>
@@ -161,7 +161,7 @@
       <dct:spatial>
         <dct:Location>
           <!--POINT(lon lat elevation)-->
-          <locn:geometry>POINT(15.004 37.734 0)</locn:geometry>
+          <locn:geometry>POINT(15.004 37.734)</locn:geometry>
         </dct:Location>
       </dct:spatial>
       <!--Temporal extent-->
@@ -192,7 +192,7 @@
       <!--Domain-->
       <eposap:domain>Volcanology</eposap:domain>
       <!--subDomain-->
-      <eposap:subDomain>Thermal infrared imagery from geostationary satellites</eposap:subDomain>
+      <eposap:subDomain>TBD</eposap:subDomain>
       <!--Data creation-->
       <dct:created>2016-05-26T08:00:00Z</dct:created>
       <!--Topic category-->
@@ -200,9 +200,9 @@
       <!--Characterset-->
       <cnt:characterEncoding>UTF-8</cnt:characterEncoding>
       <!--Point of contact-->
-      <dcat:contactPoint>OPGC_ID_01</dcat:contactPoint>
+      <dcat:contactPoint>0000-0001-8720-7300</dcat:contactPoint>
       <!--Responsible party-->
-      <eposap:responsibleParty>OPGC_ID_01</eposap:responsibleParty>
+      <eposap:responsibleParty>0000-0001-8720-7300</eposap:responsibleParty>
       <!--Spatial Resolution-->
       <rdf:comment/>
       <!--Spatial Representation Technique-->
@@ -217,7 +217,7 @@
       <dct:modified>2017-06-20T11:43:47Z</dct:modified>
       <dct:language>
         <!--Language-->
-        <dct:LinguisticSystem>English</dct:LinguisticSystem>
+        <dct:LinguisticSystem>en</dct:LinguisticSystem>
       </dct:language>
       <!--Standard Name-->
       <dct:title>20160526080000_20160526094500_Etna_ThermalState039.csv Metadata</dct:title>
@@ -228,7 +228,7 @@
       <!--Characterset-->
       <cnt:characterEncoding>UTF-8</cnt:characterEncoding>
       <!--Point of contact-->
-      <dcat:contactPoint>OPGC_ID_01</dcat:contactPoint>
+      <dcat:contactPoint>0000-0001-8720-7300</dcat:contactPoint>
       <!--Created-->
       <dct:created>2017-06-20T11:04:35Z</dct:created>
     </eposap:CatalogRecord>
@@ -253,7 +253,7 @@
       <dct:modified>2017-06-20T11:43:47Z</dct:modified>
       <!--Language-->
       <dct:language>
-        <dct:LinguisticSystem>English</dct:LinguisticSystem>
+        <dct:LinguisticSystem>en</dct:LinguisticSystem>
       </dct:language>
       <!--Lineage-->
       <dct:provenance>
@@ -277,7 +277,7 @@
       <dct:spatial>
         <dct:Location>
           <!--POINT(lon lat elevation)-->
-          <locn:geometry>POINT(15.004 37.734 0)</locn:geometry>
+          <locn:geometry>POINT(15.004 37.734)</locn:geometry>
         </dct:Location>
       </dct:spatial>
       <!--Temporal extent-->
@@ -308,7 +308,7 @@
       <!--Domain-->
       <eposap:domain>Volcanology</eposap:domain>
       <!--subDomain-->
-      <eposap:subDomain>Thermal infrared imagery from geostationary satellites</eposap:subDomain>
+      <eposap:subDomain>TBD</eposap:subDomain>
       <!--Data creation-->
       <dct:created>2016-05-26T09:45:00Z</dct:created>
       <!--Topic category-->
@@ -316,9 +316,9 @@
       <!--Characterset-->
       <cnt:characterEncoding>UTF-8</cnt:characterEncoding>
       <!--Point of contact-->
-      <dcat:contactPoint>OPGC_ID_01</dcat:contactPoint>
+      <dcat:contactPoint>0000-0001-8720-7300</dcat:contactPoint>
       <!--Responsible party-->
-      <eposap:responsibleParty>OPGC_ID_01</eposap:responsibleParty>
+      <eposap:responsibleParty>0000-0001-8720-7300</eposap:responsibleParty>
       <!--Spatial Resolution-->
       <rdf:comment/>
       <!--Spatial Representation Technique-->
@@ -333,7 +333,7 @@
       <dct:modified>2017-06-20T11:43:47Z</dct:modified>
       <dct:language>
         <!--Language-->
-        <dct:LinguisticSystem>English</dct:LinguisticSystem>
+        <dct:LinguisticSystem>en</dct:LinguisticSystem>
       </dct:language>
       <!--Standard Name-->
       <dct:title>20160526094500_20160526094500_Etna_TSR.csv Metadata</dct:title>
@@ -344,7 +344,7 @@
       <!--Characterset-->
       <cnt:characterEncoding>UTF-8</cnt:characterEncoding>
       <!--Point of contact-->
-      <dcat:contactPoint>OPGC_ID_01</dcat:contactPoint>
+      <dcat:contactPoint>0000-0001-8720-7300</dcat:contactPoint>
       <!--Created-->
       <dct:created>2017-06-20T11:43:47Z</dct:created>
     </eposap:CatalogRecord>
@@ -369,7 +369,7 @@
       <dct:modified>2017-06-20T11:43:47Z</dct:modified>
       <!--Language-->
       <dct:language>
-        <dct:LinguisticSystem>English</dct:LinguisticSystem>
+        <dct:LinguisticSystem>en</dct:LinguisticSystem>
       </dct:language>
       <!--Lineage-->
       <dct:provenance>
@@ -393,7 +393,7 @@
       <dct:spatial>
         <dct:Location>
           <!--POINT(lon lat elevation)-->
-          <locn:geometry>POINT(15.004 37.734 0)</locn:geometry>
+          <locn:geometry>POINT(15.004 37.734)</locn:geometry>
         </dct:Location>
       </dct:spatial>
       <!--Temporal extent-->
@@ -424,7 +424,7 @@
       <!--Domain-->
       <eposap:domain>Volcanology</eposap:domain>
       <!--subDomain-->
-      <eposap:subDomain>Thermal infrared imagery from geostationary satellites</eposap:subDomain>
+      <eposap:subDomain>TBD</eposap:subDomain>
       <!--Data creation-->
       <dct:created>2016-05-26T08:00:00Z</dct:created>
       <!--Topic category-->
@@ -432,9 +432,9 @@
       <!--Characterset-->
       <cnt:characterEncoding>UTF-8</cnt:characterEncoding>
       <!--Point of contact-->
-      <dcat:contactPoint>OPGC_ID_01</dcat:contactPoint>
+      <dcat:contactPoint>0000-0001-8720-7300</dcat:contactPoint>
       <!--Responsible party-->
-      <eposap:responsibleParty>OPGC_ID_01</eposap:responsibleParty>
+      <eposap:responsibleParty>0000-0001-8720-7300</eposap:responsibleParty>
       <!--Spatial Resolution-->
       <rdf:comment/>
       <!--Spatial Representation Technique-->
@@ -449,7 +449,7 @@
       <dct:modified>2017-06-20T11:43:47Z</dct:modified>
       <dct:language>
         <!--Language-->
-        <dct:LinguisticSystem>English</dct:LinguisticSystem>
+        <dct:LinguisticSystem>en</dct:LinguisticSystem>
       </dct:language>
       <!--Standard Name-->
       <dct:title>20160526080000_20160526094500_Etna_Nb_HotSpots.csv Metadata</dct:title>
@@ -460,7 +460,7 @@
       <!--Characterset-->
       <cnt:characterEncoding>UTF-8</cnt:characterEncoding>
       <!--Point of contact-->
-      <dcat:contactPoint>OPGC_ID_01</dcat:contactPoint>
+      <dcat:contactPoint>0000-0001-8720-7300</dcat:contactPoint>
       <!--Created-->
       <dct:created>2017-06-20T11:04:35Z</dct:created>
     </eposap:CatalogRecord>
@@ -485,7 +485,7 @@
       <dct:modified>2017-06-20T11:41:00Z</dct:modified>
       <!--Language-->
       <dct:language>
-        <dct:LinguisticSystem>English</dct:LinguisticSystem>
+        <dct:LinguisticSystem>en</dct:LinguisticSystem>
       </dct:language>
       <!--Lineage-->
       <dct:provenance>
@@ -540,7 +540,7 @@
       <!--Domain-->
       <eposap:domain>Volcanology</eposap:domain>
       <!--subDomain-->
-      <eposap:subDomain>Thermal infrared imagery from geostationary satellites</eposap:subDomain>
+      <eposap:subDomain>TBD</eposap:subDomain>
       <!--Data creation-->
       <dct:created>2016-05-26T08:00:00Z</dct:created>
       <!--Topic category-->
@@ -548,9 +548,9 @@
       <!--Characterset-->
       <cnt:characterEncoding>UTF-8</cnt:characterEncoding>
       <!--Point of contact-->
-      <dcat:contactPoint>OPGC_ID_01</dcat:contactPoint>
+      <dcat:contactPoint>0000-0001-8720-7300</dcat:contactPoint>
       <!--Responsible party-->
-      <eposap:responsibleParty>OPGC_ID_01</eposap:responsibleParty>
+      <eposap:responsibleParty>0000-0001-8720-7300</eposap:responsibleParty>
       <!--Spatial Resolution-->
       <rdf:comment/>
       <!--Spatial Representation Technique-->
@@ -565,7 +565,7 @@
       <dct:modified>2017-06-20T11:41:00Z</dct:modified>
       <dct:language>
         <!--Language-->
-        <dct:LinguisticSystem>English</dct:LinguisticSystem>
+        <dct:LinguisticSystem>en</dct:LinguisticSystem>
       </dct:language>
       <!--Standard Name-->
       <dct:title>201605260800_Italie_NTI_flag.tif Metadata</dct:title>
@@ -576,7 +576,7 @@
       <!--Characterset-->
       <cnt:characterEncoding>UTF-8</cnt:characterEncoding>
       <!--Point of contact-->
-      <dcat:contactPoint>OPGC_ID_01</dcat:contactPoint>
+      <dcat:contactPoint>0000-0001-8720-7300</dcat:contactPoint>
       <!--Created-->
       <dct:created>2017-06-20T11:41:39Z</dct:created>
     </eposap:CatalogRecord>
@@ -601,7 +601,7 @@
       <dct:modified>2017-06-20T11:41:39Z</dct:modified>
       <!--Language-->
       <dct:language>
-        <dct:LinguisticSystem>English</dct:LinguisticSystem>
+        <dct:LinguisticSystem>en</dct:LinguisticSystem>
       </dct:language>
       <!--Lineage-->
       <dct:provenance>
@@ -656,7 +656,7 @@
       <!--Domain-->
       <eposap:domain>Volcanology</eposap:domain>
       <!--subDomain-->
-      <eposap:subDomain>Thermal infrared imagery from geostationary satellites</eposap:subDomain>
+      <eposap:subDomain>TBD</eposap:subDomain>
       <!--Data creation-->
       <dct:created>2016-05-26T08:00:00Z</dct:created>
       <!--Topic category-->
@@ -664,9 +664,9 @@
       <!--Characterset-->
       <cnt:characterEncoding>UTF-8</cnt:characterEncoding>
       <!--Point of contact-->
-      <dcat:contactPoint>OPGC_ID_01</dcat:contactPoint>
+      <dcat:contactPoint>0000-0001-8720-7300</dcat:contactPoint>
       <!--Responsible party-->
-      <eposap:responsibleParty>OPGC_ID_01</eposap:responsibleParty>
+      <eposap:responsibleParty>0000-0001-8720-7300</eposap:responsibleParty>
       <!--Spatial Resolution-->
       <rdf:comment/>
       <!--Spatial Representation Technique-->
@@ -681,7 +681,7 @@
       <dct:modified>2017-06-20T11:41:39Z</dct:modified>
       <dct:language>
         <!--Language-->
-        <dct:LinguisticSystem>English</dct:LinguisticSystem>
+        <dct:LinguisticSystem>en</dct:LinguisticSystem>
       </dct:language>
       <!--Standard Name-->
       <dct:title>201605260800_Italie_NTI_raster.tif Metadata</dct:title>
@@ -692,7 +692,7 @@
       <!--Characterset-->
       <cnt:characterEncoding>UTF-8</cnt:characterEncoding>
       <!--Point of contact-->
-      <dcat:contactPoint>OPGC_ID_01</dcat:contactPoint>
+      <dcat:contactPoint>0000-0001-8720-7300</dcat:contactPoint>
       <!--Created-->
       <dct:created>2017-06-20T11:41:39Z</dct:created>
     </eposap:CatalogRecord>
@@ -715,12 +715,12 @@
     <!--Phone-->
     <vcard:hasTelephone>+33473405588</vcard:hasTelephone>
     <!--Unique identifier-->
-    <dct:identifier>OPGC_ID_01</dct:identifier>
+    <dct:identifier>0000-0001-8720-7300</dct:identifier>
     <!--Organisation-->
-    <eposap:affiliation>ORGA_ID_05</eposap:affiliation>
+    <eposap:affiliation>916450860</eposap:affiliation>
     <!--Language for contact-->
     <dct:language>
-      <dct:LinguisticSystem>English, French</dct:LinguisticSystem>
+      <dct:LinguisticSystem>en, fr</dct:LinguisticSystem>
     </dct:language>
     <!--Qualification-->
     <schema:qualifications>PhD.</schema:qualifications>
@@ -744,12 +744,12 @@
     <!--Phone-->
     <vcard:hasTelephone>+3373346729</vcard:hasTelephone>
     <!--Unique identifier-->
-    <dct:identifier>OPGC_ID_02</dct:identifier>
+    <dct:identifier>0000-0002-4518-3328</dct:identifier>
     <!--Organisation-->
-    <eposap:affiliation>ORGA_ID_05</eposap:affiliation>
+    <eposap:affiliation>916450860</eposap:affiliation>
     <!--Language for contact-->
     <dct:language>
-      <dct:LinguisticSystem>English, French</dct:LinguisticSystem>
+      <dct:LinguisticSystem>en, fr</dct:LinguisticSystem>
     </dct:language>
     <!--Qualification-->
     <schema:qualifications>PhD.</schema:qualifications>
@@ -773,46 +773,17 @@
     <!--Phone-->
     <vcard:hasTelephone>+33473405582</vcard:hasTelephone>
     <!--Unique identifier-->
-    <dct:identifier>OPGC_ID_03</dct:identifier>
+    <dct:identifier>0000-0002-0108-5486</dct:identifier>
     <!--Organisation-->
-    <eposap:affiliation>ORGA_ID_05</eposap:affiliation>
+    <eposap:affiliation>916450860</eposap:affiliation>
     <!--Language for contact-->
     <dct:language>
-      <dct:LinguisticSystem>English, French</dct:LinguisticSystem>
+      <dct:LinguisticSystem>en, fr</dct:LinguisticSystem>
     </dct:language>
     <!--Qualification-->
     <schema:qualifications>PhD.</schema:qualifications>
     <!--CV-->
     <vcard:hasURL>http://lmv.univ-bpclermont.fr/bachelery-patrick/</vcard:hasURL>
-  </eposap:Person>
-  <eposap:Person>
-    <!--Last Name, Given Name-->
-    <vcard:fn/>
-    <!--Postal Address-->
-    <vcard:hasAddress>
-      <vcard:Address>
-        <vcard:street-address>CNRS, 3 rue Michel-Ange</vcard:street-address>
-        <vcard:locality>PARIS CEDEX 16</vcard:locality>
-        <vcard:postal-code>75794</vcard:postal-code>
-        <vcard:country-name>FRANCE</vcard:country-name>
-      </vcard:Address>
-    </vcard:hasAddress>
-    <!--Email-->
-    <vcard:hasEmail>contact@cnrs.fr</vcard:hasEmail>
-    <!--Phone-->
-    <vcard:hasTelephone>+33144964000</vcard:hasTelephone>
-    <!--Unique identifier-->
-    <dct:identifier>CNRS_ID_01</dct:identifier>
-    <!--Organisation-->
-    <eposap:affiliation>ORGA_ID_02</eposap:affiliation>
-    <!--Language for contact-->
-    <dct:language>
-      <dct:LinguisticSystem>English, French</dct:LinguisticSystem>
-    </dct:language>
-    <!--Qualification-->
-    <schema:qualifications/>
-    <!--CV-->
-    <vcard:hasURL/>
   </eposap:Person>
   <!--EPOS Organisation-->
   <eposap:Organisation>
@@ -836,24 +807,24 @@
     <!--Logo-->
     <vcard:hasLogo>http://wwwobs.univ-bpclermont.fr/opgc/images/opgc_350t.gif</vcard:hasLogo>
     <!--Unique identifier-->
-    <dct:identifier>ORGA_ID_05</dct:identifier>
+    <dct:identifier>916450860</dct:identifier>
     <!--Scientific Contact-->
-    <eposap:scientificContact>OPGC_ID_02</eposap:scientificContact>
+    <eposap:scientificContact>0000-0002-4518-3328</eposap:scientificContact>
     <!--Spatial Coordinates-->
     <dct:spatial>
       <dct:Location>
         <!--POINT(lon lat elevation)-->
-        <locn:geometry>POINT(3.111 45.761 0)</locn:geometry>
+        <locn:geometry>POINT(3.111 45.761)</locn:geometry>
       </dct:Location>
     </dct:spatial>
     <!--Type-->
     <dct:type>OUS - Observatory of Universe Sciences</dct:type>
     <!--Legal Contact-->
-    <eposap:legalContact>OPGC_ID_03</eposap:legalContact>
+    <eposap:legalContact>0000-0002-0108-5486</eposap:legalContact>
     <!--Financial Contact-->
-    <eposap:financialContact>OPGC_ID_03</eposap:financialContact>
+    <eposap:financialContact>0000-0002-0108-5486</eposap:financialContact>
     <!--Is part of-->
-    <eposap:isPartOf>ORGA_ID_02</eposap:isPartOf>
+    <eposap:isPartOf>999997930</eposap:isPartOf>
   </eposap:Organisation>
   <eposap:Organisation>
     <!--Title (english)-->
@@ -876,22 +847,22 @@
     <!--Logo-->
     <vcard:hasLogo>http://www.cnrs.fr/fr/z-tools/newune/themes/CNRSTheme/images/logocnrs.png</vcard:hasLogo>
     <!--Unique identifier-->
-    <dct:identifier>ORGA_ID_02</dct:identifier>
+    <dct:identifier>999997930</dct:identifier>
     <!--Scientific Contact-->
-    <eposap:scientificContact>CNRS_ID_01</eposap:scientificContact>
+    <eposap:scientificContact>0000-0002-0108-5486</eposap:scientificContact>
     <!--Spatial Coordinates-->
     <dct:spatial>
       <dct:Location>
         <!--POINT(lon lat elevation)-->
-        <locn:geometry>POINT(2.264 48.847 0)</locn:geometry>
+        <locn:geometry>POINT(2.264 48.847)</locn:geometry>
       </dct:Location>
     </dct:spatial>
     <!--Type-->
     <dct:type>Scientific and Technical Establishment</dct:type>
     <!--Legal Contact-->
-    <eposap:legalContact>CNRS_ID_01</eposap:legalContact>
+    <eposap:legalContact>0000-0002-0108-5486</eposap:legalContact>
     <!--Financial Contact-->
-    <eposap:financialContact>CNRS_ID_01</eposap:financialContact>
+    <eposap:financialContact>0000-0002-0108-5486</eposap:financialContact>
   </eposap:Organisation>
   <!--EPOS Webservice-->
   <eposap:WebService>
@@ -915,7 +886,7 @@
     <dct:license>http://creativecommons.org/licenses/by-nc/4.0/</dct:license>
     <!--URI-->
     <foaf:page>
-      <foaf:primaryTopic>http://hotvolc.opgc.fr/php/data_catalog.php?</foaf:primaryTopic>
+      <foaf:primaryTopic>http://hotvolc.opgc.fr/www/php/data_catalog.php?</foaf:primaryTopic>
     </foaf:page>
     <!--distribution format, in case the service provides (also) access to binary data-->
     <dct:format>
@@ -946,10 +917,10 @@
       Earthquake parameters, Velocity models, GNSS station velocities, InSAR, Meteorology, 
       Variation of geomagnetic field, 3D/4D structural models, Analog models, Numerical models, 
       Geochemical data, Borehole data, Rock sample properties)-->
-    <eposap:subDomain>Thermal infrared imagery from geostationary satellites</eposap:subDomain>
+    <eposap:subDomain>TBD</eposap:subDomain>
     <!--Keywords, annotation. Simple and free (web annotation ontology in the future)-->
     <dcat:keyword>WebGIS, Real Time, Satellite, InfraRed, Volcanology, Lava, Ash, SO2</dcat:keyword>
-    <eposap:operation>visualise, download, etc</eposap:operation>
+    <eposap:operation>TBD</eposap:operation>
     <dct:hasVersion>2.0</dct:hasVersion>
     <!--List of Parameters:
       this section is needed in order to describe the parameters of the service.
@@ -1071,11 +1042,11 @@
     </eposap:parameter>
     <!--The document is meant to be human readable (e.g. PDF, doc, and so on).
       This will help a user who, for instance, does not understand something from the hints/label of the parameters-->
-    <schema:documentation>http://hotvolc.opgc.fr/doc/hotvolc_products_and_metadata_description.pdf</schema:documentation>
+    <schema:documentation>http://hotvolc.opgc.fr/EPOS_HOTVOLC_DDSS_Lava_Products_and_Metadata_Description.pdf</schema:documentation>
     <!--internal link to contact point (vcard:Individual) described in the same file in (eposap:Person)-->
-    <dcat:contactPoint>OPGC_ID_01</dcat:contactPoint>
+    <dcat:contactPoint>0000-0001-8720-7300</dcat:contactPoint>
     <!--internal link to responsibleParty (vcard:Organisation) described in the same file in (eposap:Organisation)-->
-    <eposap:publisher>ORGA_ID_05</eposap:publisher>
+    <eposap:publisher>916450860</eposap:publisher>
     <!--Geographic location/spatial exentent /bounding box-->
     <dct:spatial>
       <dct:Location>
@@ -1097,9 +1068,9 @@
     <!--http://dx.doi.org/10.1144/SP426.31-->
     <dct:identifier>doi_10.1144_SP426.31</dct:identifier>
     <dct:title>HOTVOLC: a web-based monitoring system for volcanic hot spots</dct:title>
-    <eposap:authors>OPGC_ID_01</eposap:authors>
+    <eposap:authors>0000-0001-8720-7300</eposap:authors>
     <!--Real Publisher : The Geological Society of London-->
-    <eposap:publisher>ORGA_ID_05</eposap:publisher>
+    <eposap:publisher>916450860</eposap:publisher>
     <dct:abstract>Infrared (IR) satellite-based sensors allow the detection and quantification of volcanic hot spots. Sensors flown on geostationary satellites are particularly helpful in the early warning and continuous tracking of effusive activity. Development of operational monitoring and dissemination systems is essential to achieve the real-time ingestion and processing of IR data for a timely response during volcanic crises. HOTVOLC is a web-based satellite-data-driven monitoring system developed at the Observatoire de Physique du Globe de Clermont-Ferrand (Clermont-Ferrand), designed to achieve near-real-time monitoring of volcanic activity using on-site ingestion of geostationary satellite data (e.g. MSG-SEVIRI, MTSAT, GOES-Imager). Here we present the characteristics of the HOTVOLC system for the monitoring of effusive activity. The system comprises two acquisition stations and secure databases (i.e. mirrored archives). The detection of volcanic hot spots uses a contextual algorithm that is based on a modified form of the Normalized Thermal Index (NTI*) and VAST. Raster images and numerical data are available to open-access on a Web-GIS interface. Tests are carried out and presented here, particularly for the 12–13 January 2011 eruption of Mount Etna, to show the capability of the system to provide quantitative information such as lava volume and time-averaged discharge rate. Examples of operational application reveal the ability of the HOTVOLC system to provide timely thermal information about volcanic hot spot activity.</dct:abstract>
     <dct:issued>2016-03-18T12:00:00Z</dct:issued>
     <schema:issn>2041-4927</schema:issn>
@@ -1107,7 +1078,7 @@
     <schema:volumeNumber>426</schema:volumeNumber>
     <schema:numberOfPages>18</schema:numberOfPages>
     <schema:keywords>Real time, Satellite, Infrared, Volcanology, WebGIS, Lava, Ash, SO2</schema:keywords>
-    <eposap:contributors>OPGC_ID_02</eposap:contributors>
+    <eposap:contributors>0000-0002-4518-3328</eposap:contributors>
     <dct:accessRights>
       <dct:RightsStatement>Pay-per-view Access</dct:RightsStatement>
     </dct:accessRights>
@@ -1132,13 +1103,13 @@
     <!--InstrumentName-->
     <dct:title>Meteosat Second Generation (MSG)</dct:title>
     <!--facility-->
-    <eposap:relatedTo>FACI_ID_01</eposap:relatedTo>
+    <eposap:relatedTo>999619533</eposap:relatedTo>
     <!--equipment-->
     <eposap:isPartOf>EQUI_ID_02</eposap:isPartOf>
     <!--person-->
-    <dcat:contactPoint>FACI_ID_01</dcat:contactPoint>
+    <dcat:contactPoint>999619533</dcat:contactPoint>
     <!--Organizaton-->
-    <eposap:owner>FACI_ID_01</eposap:owner>
+    <eposap:owner>999619533</eposap:owner>
     <dct:temporal>
       <dct:PeriodOfTime>
         <schema:startDate>2012-07-05T12:00:00Z</schema:startDate>
@@ -1169,13 +1140,13 @@
     <!--InstrumentName-->
     <dct:title>Spinning Enhanced Visible and InfraRed Imager</dct:title>
     <!--facility-->
-    <eposap:relatedTo>FACI_ID_01</eposap:relatedTo>
+    <eposap:relatedTo>999619533</eposap:relatedTo>
     <!--equipment-->
     <eposap:isPartOf>EQUI_ID_02</eposap:isPartOf>
     <!--person-->
-    <dcat:contactPoint>FACI_ID_01</dcat:contactPoint>
+    <dcat:contactPoint>999619533</dcat:contactPoint>
     <!--Organizaton-->
-    <eposap:owner>FACI_ID_01</eposap:owner>
+    <eposap:owner>999619533</eposap:owner>
     <dct:temporal>
       <dct:PeriodOfTime>
         <schema:startDate>2012-07-05T12:00:00Z</schema:startDate>
@@ -1202,7 +1173,7 @@
   </eposap:Equipment>
   <!--EPOS Facility-->
   <eposap:Facility>
-    <dct:identifier>FACI_ID_01</dct:identifier>
+    <dct:identifier>999619533</dct:identifier>
     <dct:title>EUMETSAT - The European Organisation for the Exploitation of Meteorological Satellites</dct:title>
     <!--country-->
     <vcard:hasAddress>
@@ -1214,9 +1185,9 @@
       </vcard:Address>
     </vcard:hasAddress>
     <dct:description>EUMETSAT is an intergovernmental organisation and was founded in 1986. Our purpose is to supply weather and climate-related satellite data, images and products – 24 hours a day, 365 days a year – to the National Meteorological Services of our Member and Cooperating States in Europe, and other users worldwide</dct:description>
-    <eposap:owner>FACI_ID_01</eposap:owner>
-    <dcat:contactPoint>FACI_ID_01</dcat:contactPoint>
-    <eposap:facilityManager>FACI_ID_01</eposap:facilityManager>
+    <eposap:owner>999619533</eposap:owner>
+    <dcat:contactPoint>999619533</dcat:contactPoint>
+    <eposap:facilityManager>999619533</eposap:facilityManager>
     <!--type-->
     <dct:type>European Consortium</dct:type>
     <!--website-->


### PR DESCRIPTION
*person* - dct:identifier are now orcid number
*organisation* - dct:identifier are now pic number
*webservice* - endPoint URL are now working
*eposap:subDomain* & *eposap:operation* - are now filled with 'TBD' string

update by Yannick GUEHENNEUX (y.guehenneux@opgc.fr) Engineer at OPGC