### PR TITLE
OGC WMS removed, missing a dedicated DDSS ID

### DIFF
--- a/examples/WP08/EPOS-DCAT-AP_WP08_INGV_AHEAD.xml
+++ b/examples/WP08/EPOS-DCAT-AP_WP08_INGV_AHEAD.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- AHEAD services description v1.4 (v9 internal). This file was created by Mario Locati (INGV, mario.locati@ingv.it) the 9 of March 2018. -->
+<!-- AHEAD services description v1.5 (v10 internal). This file was created by Mario Locati (INGV, mario.locati@ingv.it) the 21st of March 2018. -->
 <eposap:Epos
 	xmlns:adms="http://www.w3.org/ns/adms#"
 	xmlns:cnt="http://www.w3.org/2008/content#"
@@ -417,10 +417,13 @@
 				<schema:endDate>1899-12-31T23:59:59</schema:endDate>
 			</dct:PeriodOfTime>
 		</dct:temporal>
-    <eposap:DDSS-ID>WP8-DDSS-025</eposap:DDSS-ID>
-    <eposap:actions>download</eposap:actions>
+		<eposap:DDSS-ID>WP8-DDSS-025</eposap:DDSS-ID>
+		<eposap:actions>download</eposap:actions>
 	</eposap:WebService>
-	
+
+<!--
+Removed the OGC WMS because has the same DDSS-ID of the OGC WFS. Will re-enable it when it will be possible to obtain a dedicated ID, apparently the DDS table is now locked.
+
 	<eposap:WebService>
 		<dct:title>Archive of Historical Earthquake Data (AHEAD) event data (OGC Web Map Service)</dct:title>
 		<dct:description xml:lang="en">The OGC WMS web service providing a raster layer with epicentres for historical earthquakes from AHEAD, the European Archive of Historical Earthquake Data</dct:description>
@@ -518,10 +521,11 @@
 				<schema:endDate>1899-12-31T23:59:59</schema:endDate>
 			</dct:PeriodOfTime>
 		</dct:temporal>
-    <eposap:DDSS-ID>WP8-DDSS-025</eposap:DDSS-ID>
-    <eposap:actions>visualise</eposap:actions>
+		<eposap:DDSS-ID>WP8-DDSS-025</eposap:DDSS-ID>
+		<eposap:actions>visualise</eposap:actions>
 	</eposap:WebService>
-	
+-->
+
 	<eposap:WebService>
 		<dct:title>Archive of Historical Earthquake Data (AHEAD) macroseismic data</dct:title>
 		<dct:description xml:lang="en">Macroseismic web service providing intensity data for historical earthquakes from AHEAD, the European Archive of Historical Earthquake Data.</dct:description>

--- a/examples/WP08/EPOS-DCAT-AP_WP08_INGV_AHEAD.xml
+++ b/examples/WP08/EPOS-DCAT-AP_WP08_INGV_AHEAD.xml
@@ -422,7 +422,7 @@
 	</eposap:WebService>
 
 <!--
-Removed the OGC WMS because has the same DDSS-ID of the OGC WFS. Will re-enable it when it will be possible to obtain a dedicated ID, apparently the DDS table is now locked.
+Removed OGC WMS because has the same DDSS-ID of the OGC WFS. Will re-enable it when it will be possible to obtain a dedicated ID, apparently the DDS table is now locked.
 
 	<eposap:WebService>
 		<dct:title>Archive of Historical Earthquake Data (AHEAD) event data (OGC Web Map Service)</dct:title>
@@ -919,6 +919,7 @@ Removed the OGC WMS because has the same DDSS-ID of the OGC WFS. Will re-enable 
 		<eposap:DDSS-ID>WP8-DDSS-026</eposap:DDSS-ID>
 		<eposap:actions>download</eposap:actions>
 	</eposap:WebService>
+
 	<!--
 	<eposap:Publication>
 		<dct:identifier>doi:10.1785/0220130113</dct:identifier>

--- a/examples/WP08/EPOS-DCAT-AP_WP08_INGV_AHEAD.xml
+++ b/examples/WP08/EPOS-DCAT-AP_WP08_INGV_AHEAD.xml
@@ -349,8 +349,8 @@
 				<schema:endDate>1899-12-31T23:59:59</schema:endDate>
 			</dct:PeriodOfTime>
 		</dct:temporal>
-    <eposap:DDSS-ID>WP8-DDSS-024</eposap:DDSS-ID>
-    <eposap:actions>download, visualise</eposap:actions>
+		<eposap:DDSS-ID>WP8-DDSS-024</eposap:DDSS-ID>
+		<eposap:actions>download, visualise</eposap:actions>
 	</eposap:WebService>
 	
 	<eposap:WebService>
@@ -429,7 +429,7 @@ Removed the OGC WMS because has the same DDSS-ID of the OGC WFS. Will re-enable 
 		<dct:description xml:lang="en">The OGC WMS web service providing a raster layer with epicentres for historical earthquakes from AHEAD, the European Archive of Historical Earthquake Data</dct:description>
 		<dct:issued>2018-03-09T12:00:00</dct:issued>
 		<dct:modified>2018-03-09T12:00:00</dct:modified>
-		<dct:license xml:lang="en">https://www.emidius.eu/AHEAD/introduction.php#copyright</dct:license><!-- temporary solution, valid until a proper CC license will be selected -->
+		<dct:license xml:lang="en">https://www.emidius.eu/AHEAD/introduction.php#copyright</dct:license>
 		<foaf:page>
 			<foaf:primaryTopic>https://www.emidius.eu/services/europe/wms?</foaf:primaryTopic>
 		</foaf:page>
@@ -749,8 +749,8 @@ Removed the OGC WMS because has the same DDSS-ID of the OGC WFS. Will re-enable 
 				<schema:endDate>1899-12-31T23:59:59</schema:endDate>
 			</dct:PeriodOfTime>
 		</dct:temporal>
-    <eposap:DDSS-ID>WP8-DDSS-026</eposap:DDSS-ID>
-    <eposap:actions>download, visualise</eposap:actions>
+		<eposap:DDSS-ID>WP8-DDSS-026</eposap:DDSS-ID>
+		<eposap:actions>download, visualise</eposap:actions>
 	</eposap:WebService>
 	
 	<eposap:WebService>
@@ -916,8 +916,8 @@ Removed the OGC WMS because has the same DDSS-ID of the OGC WFS. Will re-enable 
 			</dct:Location>
 		</dct:spatial>
 		<adms:representationTechnique>point</adms:representationTechnique>
-    <eposap:DDSS-ID>WP8-DDSS-026</eposap:DDSS-ID>
-    <eposap:actions>download</eposap:actions>
+		<eposap:DDSS-ID>WP8-DDSS-026</eposap:DDSS-ID>
+		<eposap:actions>download</eposap:actions>
 	</eposap:WebService>
 	<!--
 	<eposap:Publication>


### PR DESCRIPTION
As the EPOS DDSS table is apparently locked, I removed the AHEAD OGC WMS service, which has the same DDSS ID of the AHEAD OGC WFS.
When the DDSS will be unlocked and a dedicated ID can be assigned to the AHEAD OGC WMS service, I will re-enable the service.
Decision made in accordance with the WP8 Seismology coordinators.