### PR TITLE
Split macroseismic and bibliography service

### DIFF
--- a/examples/WP08/EPOS-DCAT-AP_WP08_INGV_AHEAD.xml
+++ b/examples/WP08/EPOS-DCAT-AP_WP08_INGV_AHEAD.xml
@@ -745,7 +745,7 @@
 				<schema:endDate>1899-12-31T23:59:59</schema:endDate>
 			</dct:PeriodOfTime>
 		</dct:temporal>
-		<eposap:DDSS-ID>WP8-DDSS-026</eposap:DDSS-ID>
+		<eposap:DDSS-ID>WP8-DDSS-051</eposap:DDSS-ID>
 		<eposap:actions>download, visualise</eposap:actions>
 	</eposap:WebService>
 	


### PR DESCRIPTION
Prior to this revision, the macroseismic and the bibliography service had the same ID "WP08-DDSS-026". Now "WP08-DDSS-026" is assigned to the bibliography service, and "WP08-DDSS-051" is assigned to the macroseismic service.