### PR TITLE
Add example for Equipment WP08 (seismic stations)

### DIFF
--- a/examples/Equipment_WP08.ttl
+++ b/examples/Equipment_WP08.ttl
@@ -1,0 +1,237 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix epos: <http://www.epos-eu.org/epos/dcat-ap#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix spdx: <http://spdx.org/rdf/terms#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+</EPOS/ORFEUS/EIDA/ODC/NL.HGN..BHE> a epos:Equipment ;
+    dct:description "Specific channel recording ground motion"^^xsd:string ;
+    dct:identifier "/EPOS/ORFEUS/EIDA/ODC/NL.HGN..BHE"^^xsd:string ;
+    dct:isPartOf </EPOS/ORFEUS/EIDA/ODC/NL.HGN> ;
+    dct:spatial [ a dct:Location ;
+            locn:geometry "POINT(50.764 5.9317 135.0)"^^xsd:string ] ;
+    dct:title "Seismic Instrument for NL.HGN..BHE"^^xsd:string ;
+    dct:type "https://orfeus-eu.org/ns/channel"^^xsd:anyURI ;
+    schema:manufacturer </EPOS/ORGANIZATION/KNMI> ;
+    schema:serialNumber "NL.HGN..BHE"^^xsd:string ;
+    epos:orientation "90.0/0.0"^^xsd:string ;
+    epos:samplePeriod "0.025"^^xsd:string ;
+    dcat:contactPoint </EPOS/ORFEUS/EIDA/ODC/MRKOYMANS> .
+
+</EPOS/ORFEUS/EIDA/ODC/NL.HGN..BHN> a epos:Equipment ;
+    dct:description "Specific channel recording ground motion"^^xsd:string ;
+    dct:identifier "/EPOS/ORFEUS/EIDA/ODC/NL.HGN..BHN"^^xsd:string ;
+    dct:isPartOf </EPOS/ORFEUS/EIDA/ODC/NL.HGN> ;
+    dct:spatial [ a dct:Location ;
+            locn:geometry "POINT(50.764 5.9317 135.0)"^^xsd:string ] ;
+    dct:title "Seismic Instrument for NL.HGN..BHN"^^xsd:string ;
+    dct:type "https://orfeus-eu.org/ns/channel"^^xsd:anyURI ;
+    schema:manufacturer </EPOS/ORGANIZATION/KNMI> ;
+    schema:serialNumber "NL.HGN..BHN"^^xsd:string ;
+    epos:orientation "0.0/0.0"^^xsd:string ;
+    epos:samplePeriod "0.025"^^xsd:string ;
+    dcat:contactPoint </EPOS/ORFEUS/EIDA/ODC/MRKOYMANS> .
+
+</EPOS/ORFEUS/EIDA/ODC/NL.HGN..BHZ> a epos:Equipment ;
+    dct:description "Specific channel recording ground motion"^^xsd:string ;
+    dct:identifier "/EPOS/ORFEUS/EIDA/ODC/NL.HGN..BHZ"^^xsd:string ;
+    dct:isPartOf </EPOS/ORFEUS/EIDA/ODC/NL.HGN> ;
+    dct:spatial [ a dct:Location ;
+            locn:geometry "POINT(50.764 5.9317 135.0)"^^xsd:string ] ;
+    dct:title "Seismic Instrument for NL.HGN..BHZ"^^xsd:string ;
+    dct:type "https://orfeus-eu.org/ns/channel"^^xsd:anyURI ;
+    schema:manufacturer </EPOS/ORGANIZATION/KNMI> ;
+    schema:serialNumber "NL.HGN..BHZ"^^xsd:string ;
+    epos:orientation "0.0/-90.0"^^xsd:string ;
+    epos:samplePeriod "0.025"^^xsd:string ;
+    dcat:contactPoint </EPOS/ORFEUS/EIDA/ODC/MRKOYMANS> .
+
+</EPOS/ORFEUS/EIDA/ODC/NL.HGN.00.BHE> a epos:Equipment ;
+    dct:description "Specific channel recording ground motion"^^xsd:string ;
+    dct:identifier "/EPOS/ORFEUS/EIDA/ODC/NL.HGN.00.BHE"^^xsd:string ;
+    dct:isPartOf </EPOS/ORFEUS/EIDA/ODC/NL.HGN> ;
+    dct:spatial [ a dct:Location ;
+            locn:geometry "POINT(50.764 5.9317 135.0)"^^xsd:string ] ;
+    dct:title "Seismic Instrument for NL.HGN.00.BHE"^^xsd:string ;
+    dct:type "https://orfeus-eu.org/ns/channel"^^xsd:anyURI ;
+    schema:manufacturer </EPOS/ORGANIZATION/KNMI> ;
+    schema:serialNumber "NL.HGN.00.BHE"^^xsd:string ;
+    epos:orientation "90.0/0.0"^^xsd:string ;
+    epos:samplePeriod "0.025"^^xsd:string ;
+    dcat:contactPoint </EPOS/ORFEUS/EIDA/ODC/MRKOYMANS> .
+
+</EPOS/ORFEUS/EIDA/ODC/NL.HGN.00.BHN> a epos:Equipment ;
+    dct:description "Specific channel recording ground motion"^^xsd:string ;
+    dct:identifier "/EPOS/ORFEUS/EIDA/ODC/NL.HGN.00.BHN"^^xsd:string ;
+    dct:isPartOf </EPOS/ORFEUS/EIDA/ODC/NL.HGN> ;
+    dct:spatial [ a dct:Location ;
+            locn:geometry "POINT(50.764 5.9317 135.0)"^^xsd:string ] ;
+    dct:title "Seismic Instrument for NL.HGN.00.BHN"^^xsd:string ;
+    dct:type "https://orfeus-eu.org/ns/channel"^^xsd:anyURI ;
+    schema:manufacturer </EPOS/ORGANIZATION/KNMI> ;
+    schema:serialNumber "NL.HGN.00.BHN"^^xsd:string ;
+    epos:orientation "0.0/0.0"^^xsd:string ;
+    epos:samplePeriod "0.025"^^xsd:string ;
+    dcat:contactPoint </EPOS/ORFEUS/EIDA/ODC/MRKOYMANS> .
+
+</EPOS/ORFEUS/EIDA/ODC/NL.HGN.00.BHZ> a epos:Equipment ;
+    dct:description "Specific channel recording ground motion"^^xsd:string ;
+    dct:identifier "/EPOS/ORFEUS/EIDA/ODC/NL.HGN.00.BHZ"^^xsd:string ;
+    dct:isPartOf </EPOS/ORFEUS/EIDA/ODC/NL.HGN> ;
+    dct:spatial [ a dct:Location ;
+            locn:geometry "POINT(50.764 5.9317 135.0)"^^xsd:string ] ;
+    dct:title "Seismic Instrument for NL.HGN.00.BHZ"^^xsd:string ;
+    dct:type "https://orfeus-eu.org/ns/channel"^^xsd:anyURI ;
+    schema:manufacturer </EPOS/ORGANIZATION/KNMI> ;
+    schema:serialNumber "NL.HGN.00.BHZ"^^xsd:string ;
+    epos:orientation "0.0/-90.0"^^xsd:string ;
+    epos:samplePeriod "0.025"^^xsd:string ;
+    dcat:contactPoint </EPOS/ORFEUS/EIDA/ODC/MRKOYMANS> .
+
+</EPOS/ORFEUS/EIDA/ODC/NL.HGN.01.BHE> a epos:Equipment ;
+    dct:description "Specific channel recording ground motion"^^xsd:string ;
+    dct:identifier "/EPOS/ORFEUS/EIDA/ODC/NL.HGN.01.BHE"^^xsd:string ;
+    dct:isPartOf </EPOS/ORFEUS/EIDA/ODC/NL.HGN> ;
+    dct:spatial [ a dct:Location ;
+            locn:geometry "POINT(50.764 5.9317 135.0)"^^xsd:string ] ;
+    dct:title "Seismic Instrument for NL.HGN.01.BHE"^^xsd:string ;
+    dct:type "https://orfeus-eu.org/ns/channel"^^xsd:anyURI ;
+    schema:manufacturer </EPOS/ORGANIZATION/KNMI> ;
+    schema:serialNumber "NL.HGN.01.BHE"^^xsd:string ;
+    epos:orientation "90.0/0.0"^^xsd:string ;
+    epos:samplePeriod "0.025"^^xsd:string ;
+    dcat:contactPoint </EPOS/ORFEUS/EIDA/ODC/MRKOYMANS> .
+
+</EPOS/ORFEUS/EIDA/ODC/NL.HGN.01.BHN> a epos:Equipment ;
+    dct:description "Specific channel recording ground motion"^^xsd:string ;
+    dct:identifier "/EPOS/ORFEUS/EIDA/ODC/NL.HGN.01.BHN"^^xsd:string ;
+    dct:isPartOf </EPOS/ORFEUS/EIDA/ODC/NL.HGN> ;
+    dct:spatial [ a dct:Location ;
+            locn:geometry "POINT(50.764 5.9317 135.0)"^^xsd:string ] ;
+    dct:title "Seismic Instrument for NL.HGN.01.BHN"^^xsd:string ;
+    dct:type "https://orfeus-eu.org/ns/channel"^^xsd:anyURI ;
+    schema:manufacturer </EPOS/ORGANIZATION/KNMI> ;
+    schema:serialNumber "NL.HGN.01.BHN"^^xsd:string ;
+    epos:orientation "0.0/0.0"^^xsd:string ;
+    epos:samplePeriod "0.025"^^xsd:string ;
+    dcat:contactPoint </EPOS/ORFEUS/EIDA/ODC/MRKOYMANS> .
+
+</EPOS/ORFEUS/EIDA/ODC/NL.HGN.01.BHZ> a epos:Equipment ;
+    dct:description "Specific channel recording ground motion"^^xsd:string ;
+    dct:identifier "/EPOS/ORFEUS/EIDA/ODC/NL.HGN.01.BHZ"^^xsd:string ;
+    dct:isPartOf </EPOS/ORFEUS/EIDA/ODC/NL.HGN> ;
+    dct:spatial [ a dct:Location ;
+            locn:geometry "POINT(50.764 5.9317 135.0)"^^xsd:string ] ;
+    dct:title "Seismic Instrument for NL.HGN.01.BHZ"^^xsd:string ;
+    dct:type "https://orfeus-eu.org/ns/channel"^^xsd:anyURI ;
+    schema:manufacturer </EPOS/ORGANIZATION/KNMI> ;
+    schema:serialNumber "NL.HGN.01.BHZ"^^xsd:string ;
+    epos:orientation "0.0/-90.0"^^xsd:string ;
+    epos:samplePeriod "0.025"^^xsd:string ;
+    dcat:contactPoint </EPOS/ORFEUS/EIDA/ODC/MRKOYMANS> .
+
+</EPOS/ORFEUS/EIDA/ODC/NL.HGN.02.BHE> a epos:Equipment ;
+    dct:description "Specific channel recording ground motion"^^xsd:string ;
+    dct:identifier "/EPOS/ORFEUS/EIDA/ODC/NL.HGN.02.BHE"^^xsd:string ;
+    dct:isPartOf </EPOS/ORFEUS/EIDA/ODC/NL.HGN> ;
+    dct:spatial [ a dct:Location ;
+            locn:geometry "POINT(50.764 5.9317 135.0)"^^xsd:string ] ;
+    dct:title "Seismic Instrument for NL.HGN.02.BHE"^^xsd:string ;
+    dct:type "https://orfeus-eu.org/ns/channel"^^xsd:anyURI ;
+    schema:manufacturer </EPOS/ORGANIZATION/KNMI> ;
+    schema:serialNumber "NL.HGN.02.BHE"^^xsd:string ;
+    epos:orientation "90.0/0.0"^^xsd:string ;
+    epos:samplePeriod "0.025"^^xsd:string ;
+    dcat:contactPoint </EPOS/ORFEUS/EIDA/ODC/MRKOYMANS> .
+
+</EPOS/ORFEUS/EIDA/ODC/NL.HGN.02.BHN> a epos:Equipment ;
+    dct:description "Specific channel recording ground motion"^^xsd:string ;
+    dct:identifier "/EPOS/ORFEUS/EIDA/ODC/NL.HGN.02.BHN"^^xsd:string ;
+    dct:isPartOf </EPOS/ORFEUS/EIDA/ODC/NL.HGN> ;
+    dct:spatial [ a dct:Location ;
+            locn:geometry "POINT(50.764 5.9317 135.0)"^^xsd:string ] ;
+    dct:title "Seismic Instrument for NL.HGN.02.BHN"^^xsd:string ;
+    dct:type "https://orfeus-eu.org/ns/channel"^^xsd:anyURI ;
+    schema:manufacturer </EPOS/ORGANIZATION/KNMI> ;
+    schema:serialNumber "NL.HGN.02.BHN"^^xsd:string ;
+    epos:orientation "0.0/0.0"^^xsd:string ;
+    epos:samplePeriod "0.025"^^xsd:string ;
+    dcat:contactPoint </EPOS/ORFEUS/EIDA/ODC/MRKOYMANS> .
+
+</EPOS/ORFEUS/EIDA/ODC/NL.HGN.02.BHZ> a epos:Equipment ;
+    dct:description "Specific channel recording ground motion"^^xsd:string ;
+    dct:identifier "/EPOS/ORFEUS/EIDA/ODC/NL.HGN.02.BHZ"^^xsd:string ;
+    dct:isPartOf </EPOS/ORFEUS/EIDA/ODC/NL.HGN> ;
+    dct:spatial [ a dct:Location ;
+            locn:geometry "POINT(50.764 5.9317 135.0)"^^xsd:string ] ;
+    dct:title "Seismic Instrument for NL.HGN.02.BHZ"^^xsd:string ;
+    dct:type "https://orfeus-eu.org/ns/channel"^^xsd:anyURI ;
+    schema:manufacturer </EPOS/ORGANIZATION/KNMI> ;
+    schema:serialNumber "NL.HGN.02.BHZ"^^xsd:string ;
+    epos:orientation "0.0/-90.0"^^xsd:string ;
+    epos:samplePeriod "0.025"^^xsd:string ;
+    dcat:contactPoint </EPOS/ORFEUS/EIDA/ODC/MRKOYMANS> .
+
+</EPOS/ORFEUS/EIDA/ODC/NL> a epos:Facility ;
+    dct:description "Seismic Network: Netherlands Seismic and Acoustic Network"^^xsd:string ;
+    dct:identifier "/EPOS/ORFEUS/EIDA/ODC/NL"^^xsd:string ;
+    dct:title "Seismic Network"^^xsd:string ;
+    dct:type "https://orfeus-eu.org/ns/network"^^xsd:anyURI ;
+    dcat:contactPoint </EPOS/ORFEUS/EIDA/ODC/MRKOYMANS> ;
+    dcat:theme <SeismicNetwork> .
+
+<SeismicNetwork> a skos:Concept ;
+    dct:description "Collection of seismic stations in a seismic network"^^xsd:string ;
+    skos:inScheme <Seismology> ;
+    skos:prefLabel "Seismic Network"^^xsd:string .
+
+<Seismology> a skos:ConceptScheme ;
+    dct:description "It contains the concepts of the Seismology domain"^^xsd:string ;
+    dct:title "Seismology"^^xsd:string .
+
+</EPOS/ORFEUS/EIDA/ODC/NL.HGN> a epos:Equipment ;
+    dct:description "Seismic station"^^xsd:string ;
+    dct:identifier "/EPOS/ORFEUS/EIDA/ODC/NL.HGN"^^xsd:string ;
+    dct:spatial [ a dct:Location ;
+            locn:geometry "POINT(50.764 5.9317 135.0)"^^xsd:string ] ;
+    dct:title "Seismic Station for NL.HGN"^^xsd:string ;
+    dct:type "https://orfeus-eu.org/ns/station"^^xsd:anyURI ;
+    schema:manufacturer </EPOS/ORGANIZATION/KNMI> ;
+    schema:serialNumber "NL.HGN"^^xsd:string ;
+    dcat:contactPoint </EPOS/ORFEUS/EIDA/ODC/MRKOYMANS> .
+
+</EPOS/ORGANIZATION/KNMI> a schema:Organization ;
+    schema:address [ a schema:PostalAddress ;
+            schema:addressCountry "The Netherlands"^^xsd:string ;
+            schema:addressLocality "De Bilt"^^xsd:string ;
+            schema:postalCode "3731GA"^^xsd:string ;
+            schema:streetAddress "Utrechtseweg, 297"^^xsd:string ] ;
+    schema:identifier [ a schema:PropertyValue ;
+            schema:propertyID "PIC"^^xsd:string ;
+            schema:value "999518944"^^xsd:string ] ;
+    schema:legalName "KNMI Dutch Royal Metereological Institute"^^xsd:string ;
+    schema:leiCode "Whatever"^^xsd:string ;
+    schema:logo "http://cdn.knmi.nl/assets/logo_large-1f49334b8856e16f352187f1b52d0edf258976c6329407b0b75f5f109ea012fb.png"^^xsd:anyURI ;
+    schema:owns </EPOS/ORFEUS/EIDA/ODC/NL> ;
+    schema:url "http://www.knmi.nl"^^xsd:anyURI .
+
+</EPOS/ORFEUS/EIDA/ODC/MRKOYMANS> a schema:ContactPoint ;
+    schema:availableLanguage "NL, EN"^^xsd:string ;
+    schema:contactType "scientificContact"^^xsd:string ;
+    schema:email "koymans@knmi.nl"^^xsd:string ;
+    schema:name "Mathijs Koymans"^^xsd:string ;
+    schema:telephone "030-2206911"^^xsd:string .


### PR DESCRIPTION
Begin of mapping of the following:

* seismic stations to `Equipment`
* seismic channels to `Equipment`
* seismic networks to `Facility`

It validates against the `epos-dcat-ap_shapes.ttl` file using (http://shacl.org/playground/). There is some extra information to make it validate properly.