### PR TITLE
Change samplePeriod desc. and set xsd:string to xsd:float

### DIFF
--- a/epos-dcat-ap_shapes.ttl
+++ b/epos-dcat-ap_shapes.ttl
@@ -187,7 +187,7 @@ epos:filter
 .
 epos:samplePeriod
   rdf:type owl:DatatypeProperty ;
-  rdfs:comment "This property contains the sample period in mS"@en  ;
+  rdfs:comment "This property contains the sample period in ms"@en  ;
   rdfs:domain epos:Equipment ;
   rdfs:range rdfs:Literal ;
 .
@@ -1178,7 +1178,7 @@ epos:EquipmentShape
 
  sh:property [
       sh:path epos:samplePeriod ;
-      sh:datatype xsd:string;
+      sh:datatype xsd:float;
  ] ;
 
  sh:property [


### PR DESCRIPTION
Should the sample period be a `xsd:float` instead of a `xsd:string`? Since the unit is defined in `ms`.