### PR TITLE
Epos dcat ap shapes

### DIFF
--- a/epos-dcat-ap_shapes.ttl
+++ b/epos-dcat-ap_shapes.ttl
@@ -834,19 +834,6 @@ epos:WebServiceShape
      sh:severity sh:Warning ;
     ] ;
 
- sh:property [
-      sh:path dct:spatial ;
-      sh:class dct:Location;
-    ] ;
-
-  sh:property [
-     sh:path dct:spatial ;
-     sh:class dct:Location ;
-     sh:minCount 1 ;
-     sh:message "Spatial coverage is recommended. Please fill in a value"@en  ;
-     sh:severity sh:Warning ;
-    ] ;
-
   sh:property [
       sh:path schema:name ;
       sh:maxCount 1 ;
@@ -933,6 +920,11 @@ epos:WebServiceShape
 ####
 # WebService Optional properties
 ###
+
+ sh:property [
+      sh:path dct:spatial ;
+      sh:class dct:Location;
+    ] ;
 
   sh:property [
       sh:path hydra:supportedOperation ;

--- a/epos-dcat-ap_shapes.ttl
+++ b/epos-dcat-ap_shapes.ttl
@@ -840,6 +840,14 @@ epos:WebServiceShape
     ] ;
 
   sh:property [
+     sh:path dct:spatial ;
+     sh:class dct:Location ;
+     sh:minCount 1 ;
+     sh:message "Spatial coverage is recommended. Please fill in a value"@en  ;
+     sh:severity sh:Warning ;
+    ] ;
+
+  sh:property [
       sh:path schema:name ;
       sh:maxCount 1 ;
       sh:datatype xsd:string;

--- a/epos-dcat-ap_shapes.ttl
+++ b/epos-dcat-ap_shapes.ttl
@@ -834,6 +834,11 @@ epos:WebServiceShape
      sh:severity sh:Warning ;
     ] ;
 
+ sh:property [
+      sh:path dct:spatial ;
+      sh:class dct:Location;
+    ] ;
+
   sh:property [
       sh:path schema:name ;
       sh:maxCount 1 ;


### PR DESCRIPTION
Is `epos:WebService` supposed to have an optional `dct:spatial` property that defines the spatial coverage of the service?

https://raw.githubusercontent.com/epos-eu/EPOS-DCAT-AP/EPOS-DCAT-AP-shapes/EPOS_DCAT-AP_0.10.png