### PR TITLE
add WP8 LMU turtle file

### DIFF
--- a/examples/WP08/WP8-LMU-20180913.ttl
+++ b/examples/WP08/WP8-LMU-20180913.ttl
@@ -1,0 +1,602 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .  
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .  
+@prefix epos: <https://www.epos-eu.org/epos-dcat-ap#> .  
+@prefix dc: <http://purl.org/dc/elements/1.1/> .  
+@prefix dct: <http://purl.org/dc/terms/> .  
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .  
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .  
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .  
+@prefix schema: <http://schema.org/> .  
+@prefix dcat: <http://www.w3.org/ns/dcat#> .  
+@prefix cnt: <http://www.w3.org/2011/content#> .  
+@prefix locn: <http://www.w3.org/ns/locn#> .  
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .  
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .  
+@prefix http: <http://www.w3.org/2006/http#> .  
+@prefix owl: <http://www.w3.org/2002/07/owl#> .  
+@prefix gsp: <http://www.opengis.net/ont/geosparql#> .  
+	<#Seismology> a skos:ConceptScheme;
+		dct:title "Seismology";
+		dct:description "It contains the concepts of Seismology";
+. 
+	<#waveformquality> a skos:Concept;
+		skos:inScheme <#Seismology>;
+. 
+	<#Seismicwaveforms> a skos:Concept;
+		skos:inScheme <#Seismology>;
+. 
+	<#Seismicstations> a skos:Concept;
+		skos:inScheme <#Seismology>;
+. 
+
+<https://orcid.org/0000-0002-4088-1792> a schema:Person;
+	schema:identifier [ a schema:PropertyValue;
+		schema:propertyID "orcid";
+		schema:value "https://orcid.org/0000-0002-4088-1792";
+	]; 
+	schema:familyName "Wassermann";
+	schema:givenName "Joachim";
+	schema:address [ a schema:PostalAddress;
+		schema:streetAddress "Ludwigshöhe 8";
+		schema:addressLocality "Fürstenfeldbruck";
+		schema:postalCode "82256";
+		schema:addressCountry "Germany";
+	]; 
+	schema:email "j.wassermann@lmu.de";
+	schema:telephone "+4989218073962";
+	schema:qualifications "Researcher, Data Management";
+	schema:affiliation <PIC:999978433>;
+	schema:contactPoint <https://orcid.org/0000-0002-4088-1792/legalContact>;
+. 
+	<erde.geophysik.uni-muenchen.de/fdsnws/dataselect/1/query/operation> a hydra:Operation;
+		hydra:method "GET"^^xsd:string;
+		hydra:returns "binary";
+		hydra:property[ a hydra:IriTemplate;
+			hydra:template "http://erde.geophysik.uni-muenchen.de/fdsnws/dataselect/1/query{?starttime, endtime, network, station, location, channel, quality, minimumlength, nodata}"^^xsd:string;
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "starttime"^^xsd:string;
+					rdfs:range "xsd:date";
+					rdfs:label "Start of the timespan";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "1980-01-01T00:00:00"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "endtime"^^xsd:string;
+					rdfs:range "xsd:date";
+					rdfs:label "End of the timespan";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "2019-01-01T00:00:00"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "network"^^xsd:string;
+					rdfs:range "xsd:string";
+					rdfs:label "Network code";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "*"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "station"^^xsd:string;
+					rdfs:range "xsd:string";
+					rdfs:label "Station code";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "*"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "location"^^xsd:string;
+					rdfs:range "xsd:string";
+					rdfs:label "Location code";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "*"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "channel"^^xsd:string;
+					rdfs:range "xsd:string";
+					rdfs:label "Channel code";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "*"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "quality"^^xsd:string;
+					rdfs:range "xsd:string";
+					rdfs:label "Quality";
+					http:paramValue "B";
+					http:paramValue "M";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "minimumlength"^^xsd:string;
+					rdfs:range "xsd:integer";
+					rdfs:label "Minimum Length";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "nodata"^^xsd:string;
+					rdfs:range "xsd:integer";
+					rdfs:label "HTTP error code if no data is found";
+					http:paramValue "204";
+					http:paramValue "404";
+					hydra:required "true"^^xsd:boolean;
+				];
+		] ;
+. 
+	<erde.geophysik.uni-muenchen.de/fdsnws/station/1/query/operation> a hydra:Operation;
+		hydra:method "GET"^^xsd:string;
+		hydra:returns "xml";
+		hydra:property[ a hydra:IriTemplate;
+			hydra:template "http://erde.geophysik.uni-muenchen.de/fdsnws/station/1/query{?starttime, endtime, network, station, location, channel, minlatitude, maxlatitude, minlongitude, maxlongitude, level, nodata}"^^xsd:string;
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "starttime"^^xsd:string;
+					rdfs:range "xsd:date";
+					rdfs:label "Start of the timespan";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "1980-01-01T00:00:00"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "endtime"^^xsd:string;
+					rdfs:range "xsd:date";
+					rdfs:label "End of the timespan";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "2019-01-01T00:00:00"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "network"^^xsd:string;
+					rdfs:range "xsd:string";
+					rdfs:label "Network code";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "*"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "station"^^xsd:string;
+					rdfs:range "xsd:string";
+					rdfs:label "Station code";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "*"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "location"^^xsd:string;
+					rdfs:range "xsd:string";
+					rdfs:label "Location code";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "*"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "channel"^^xsd:string;
+					rdfs:range "xsd:string";
+					rdfs:label "Channel code";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "*"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "minlatitude"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Minimum Latitude";
+					schema:minValue "-90.0";
+					schema:maxValue "90.0";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "-90.0"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "maxlatitude"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Maximum Latitude";
+					schema:minValue "-90.0";
+					schema:maxValue "90.0";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "90.0"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "minlongitude"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Minimum Longitude";
+					schema:minValue "-180.0";
+					schema:maxValue "180.0";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "-180.0"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "maxlongitude"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Maximum Longitude";
+					schema:minValue "-180.0";
+					schema:maxValue "180.0";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "180.0"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "level"^^xsd:string;
+					rdfs:range "xsd:string";
+					rdfs:label "Level";
+					http:paramValue "network";
+					http:paramValue "station";
+					http:paramValue "channel";
+					http:paramValue "response";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "station"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "nodata"^^xsd:string;
+					rdfs:range "xsd:integer";
+					rdfs:label "HTTP error code if no data is found";
+					http:paramValue "204";
+					http:paramValue "404";
+					hydra:required "true"^^xsd:boolean;
+				];
+		] ;
+. 
+	<erde.geophysik.uni-muenchen.de/eidaws/wfcatalog/1/operation> a hydra:Operation;
+		hydra:method "GET"^^xsd:string;
+		hydra:returns "json";
+		hydra:property[ a hydra:IriTemplate;
+			hydra:template "http://erde.geophysik.uni-muenchen.de/eidaws/wfcatalog/1/query{?starttime, endtime, percent_availability_gt, percent_availability_lt, num_gaps_gt, num_gaps_lt, num_overlaps_gt, num_overlaps_lt, sample_stdev_gt, sample_stdev_lt, sample_rms_gt, sample_rms_lt, max_gap_gt, max_gap_lt, sample_min_gt, sample_min_lt, sample_max_gt, sample_max_lt, sample_mean_gt, sample_mean_lt, network, station, location, channel, csegments, longestonly, minlen, include}"^^xsd:string;
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "starttime"^^xsd:string;
+					rdfs:range "xsd:time";
+					rdfs:label "Starttime of documents";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "1980-01-01T00:00:00"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "endtime"^^xsd:string;
+					rdfs:range "xsd:time";
+					rdfs:label "Endtime of documents";
+					hydra:required "true"^^xsd:boolean;
+					schema:defaultValue "2019-01-01T00:00:00"
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "percent_availability_gt"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Data availability percentage greater than";
+					schema:maxValue "100";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "percent_availability_lt"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Data availability percentage smaller than";
+					schema:maxValue "100";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "num_gaps_gt"^^xsd:string;
+					rdfs:range "xsd:integer";
+					rdfs:label "Number of data gaps greater than";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "num_gaps_lt"^^xsd:string;
+					rdfs:range "xsd:integer";
+					rdfs:label "Number of data gaps smaller than";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "num_overlaps_gt"^^xsd:string;
+					rdfs:range "xsd:integer";
+					rdfs:label "Number of data overlaps greater than";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "num_overlaps_lt"^^xsd:string;
+					rdfs:range "xsd:integer";
+					rdfs:label "Number of data overlaps smaller than";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "sample_stdev_gt"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Standard deviation of samples greater than";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "sample_stdev_lt"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Standard deviation of samples smaller than";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "sample_rms_gt"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Standard quadratic mean of samples greater than";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "sample_rms_lt"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Standard quadratic mean of samples smaller than";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "max_gap_gt"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Maximum data gap greater than";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "max_gap_lt"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Maximum data gap smaller than";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "sample_min_gt"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Minimum data sample value greater than";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "sample_min_lt"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Minimum data sample value smaller than";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "sample_max_gt"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Maximum data sample value greater than";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "sample_max_lt"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Maximum data sample value smaller than";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "sample_mean_gt"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Mean data sample value greater than";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "sample_mean_lt"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Mean data sample value smaller than";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "network"^^xsd:string;
+					rdfs:range "xsd:string";
+					rdfs:label "Stream network code";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "station"^^xsd:string;
+					rdfs:range "xsd:string";
+					rdfs:label "Stream station code";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "location"^^xsd:string;
+					rdfs:range "xsd:string";
+					rdfs:label "Stream location code";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "channel"^^xsd:string;
+					rdfs:range "xsd:string";
+					rdfs:label "Stream channel code";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "csegments"^^xsd:string;
+					rdfs:range "xsd:boolean";
+					rdfs:label "Include continuous segments in result";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "longestonly"^^xsd:string;
+					rdfs:range "xsd:boolean";
+					rdfs:label "Include only the longest continuous segment";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "minlen"^^xsd:string;
+					rdfs:range "xsd:float";
+					rdfs:label "Limit continuous segments to this length";
+					hydra:required "true"^^xsd:boolean;
+				];
+				hydra:mapping[ a hydra:IriTemplateMapping;
+					hydra:variable "include"^^xsd:string;
+					rdfs:range "xsd:string";
+					rdfs:label "The included level of detail in response";
+					http:paramValue "default";
+					http:paramValue "samples";
+					http:paramValue "header";
+					http:paramValue "all";
+					hydra:required "true"^^xsd:boolean;
+				];
+		] ;
+. 
+
+<PIC:999978433> a schema:Organization;
+	schema:identifier [ a schema:PropertyValue;
+		schema:propertyID "pic";
+		schema:value "999978433";
+	]; 
+	schema:legalName "Ludwig-Maximilians-Universität München";
+	schema:address [ a schema:PostalAddress;
+		schema:streetAddress "Geschwister-Scholl-Platz 1";
+		schema:addressLocality "München";
+		schema:postalCode "80539";
+		schema:addressCountry "Germany";
+	]; 
+	schema:logo "https://upload.wikimedia.org/wikipedia/commons/thumb/0/06/LMU_Muenchen_Logo.svg/760px-LMU_Muenchen_Logo.svg.png"^^xsd:anyURI;
+	schema:url "https://www.geophysik.uni-muenchen.de/"^^xsd:anyURI;
+	schema:email "geophys@geophysik.uni-muenchen.de";
+	schema:telephone "+498921804226";
+	schema:contactPoint <https://orcid.org/0000-0002-4088-1792/legalContact>;
+. 
+
+<erde.geophysik.uni-muenchen.de/fdsnws/station/1/query> a epos:WebService;
+	schema:identifier "erde.geophysik.uni-muenchen.de/fdsnws/station/1/query";
+	#schema:identifier [ a schema:PropertyValue; 
+		#schema:propertyID  "DDSS-ID"; 
+		#schema:value  ""; 
+	#]; 
+	schema:description "FDSN Standard webservice at LMU to download seismic metadata";
+	dcat:theme <#Seismicstations>;
+	schema:name "FDSN Station-WS - Ludwig-Maximilians-Universität München (LMU)";
+	hydra:entrypoint "http://erde.geophysik.uni-muenchen.de/fdsnws/station/1/query?"^^xsd:anyURI; 
+	schema:provider <PIC:999978433>;
+	schema:datePublished "2016-01-01"^^xsd:date;
+	schema:dateModified "2016-01-01"^^xsd:date;
+	dct:spatial [ a dct:Location; 
+		locn:geometry "POLYGON(180.0 -90.0,-180.0 -90.0,-180.0 90.0,180.0 90.0,180.0 -90.0)"^^gsp:wktLiteral; 
+	]; 
+	hydra:supportedOperation <erde.geophysik.uni-muenchen.de/fdsnws/station/1/query/operation>;
+	schema:keywords "seismology"," seismicity"," earthquakes"," waveform"," seismic hazard"," earth structure"," earthquake intensity"," macroseismic"," macroseismic information"," waveform modeling";
+	dct:license "To be defined!"^^xsd:anyURI;
+	dct:temporal [ a dct:PeriodOfTime; 
+		schema:startDate "1993-01-01T00:00:00Z"^^xsd:dateTime; 
+		#schema:endDate "YYYY-MM-DDThh:mm:ssZ"^^xsd:dateTime; 
+	]; 
+	dcat:contactPoint <https://orcid.org/0000-0002-4088-1792/contactPoint>;
+. 
+
+<erde.geophysik.uni-muenchen.de/fdsnws/dataselect/1/query> a epos:WebService;
+	schema:identifier "erde.geophysik.uni-muenchen.de/fdsnws/dataselect/1/query";
+	#schema:identifier [ a schema:PropertyValue; 
+		#schema:propertyID  "DDSS-ID"; 
+		#schema:value  ""; 
+	#]; 
+	schema:description "FDSN Standard webservice at LMU to download waveform data";
+	dcat:theme <#Seismicwaveforms>;
+	schema:name "FDSN Dataselect - Ludwig-Maximilians-Universität München (LMU)";
+	hydra:entrypoint "http://erde.geophysik.uni-muenchen.de/fdsnws/dataselect/1/query?"^^xsd:anyURI; 
+	schema:provider <PIC:999978433>;
+	schema:datePublished "2016-01-01"^^xsd:date;
+	schema:dateModified "2016-01-01"^^xsd:date;
+	dct:spatial [ a dct:Location; 
+		locn:geometry "POLYGON(180.0 -90.0,-180.0 -90.0,-180.0 90.0,180.0 90.0,180.0 -90.0)"^^gsp:wktLiteral; 
+	]; 
+	hydra:supportedOperation <erde.geophysik.uni-muenchen.de/fdsnws/dataselect/1/query/operation>;
+	schema:keywords "seismology"," seismicity"," earthquakes"," waveform"," seismic hazard"," earth structure"," earthquake intensity"," macroseismic"," macroseismic information"," waveform modeling"," GFZ","Dataselect","FDSN-WS","Seismic Waveform","EIDA";
+	dct:license "To be defined!"^^xsd:anyURI;
+	dct:temporal [ a dct:PeriodOfTime; 
+		schema:startDate "1993-01-01T00:00:00Z"^^xsd:dateTime; 
+		#schema:endDate "YYYY-MM-DDThh:mm:ssZ"^^xsd:dateTime; 
+	]; 
+	dcat:contactPoint <https://orcid.org/0000-0002-4088-1792/contactPoint>;
+. 
+
+<erde.geophysik.uni-muenchen.de/eidaws/wfcatalog/1/query> a epos:WebService;
+	schema:identifier "erde.geophysik.uni-muenchen.de/eidaws/wfcatalog/1/query";
+	#schema:identifier [ a schema:PropertyValue; 
+		#schema:propertyID  "DDSS-ID"; 
+		#schema:value  ""; 
+	#]; 
+	schema:description "Web service which returns waveform metadata and data quality metrics";
+	dcat:theme <#waveformquality>;
+	schema:name "WFCatalog - Ludwig-Maximilians-Universität München (LMU)";
+	hydra:entrypoint "http://erde.geophysik.uni-muenchen.de/eidaws/wfcatalog/1/query?"^^xsd:anyURI; 
+	schema:provider <PIC:999978433>;
+	schema:datePublished "2017-09-01"^^xsd:date;
+	schema:dateModified "2017-09-01"^^xsd:date;
+	dct:spatial [ a dct:Location; 
+		locn:geometry "POLYGON(-180.0 -90.0,180.0 -90.0,180.0 90.0,-180.0 90.0,-180.0 -90.0)"^^gsp:wktLiteral; 
+	]; 
+	schema:keywords "EIDA"," LMU"," data quality"," availability"," metrics"," waveform"," metadata";
+	dct:license "Creative Commons for data, Open Source licences for software"^^xsd:anyURI;
+	dct:temporal [ a dct:PeriodOfTime; 
+		schema:startDate "1993-01-01T00:00:00Z"^^xsd:dateTime; 
+		#schema:endDate "YYYY-MM-DDThh:mm:ssZ"^^xsd:dateTime; 
+	]; 
+.
+# Dataset
+<https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/001/LMU> a dcat:Dataset;
+        dct:title "Primary Seismic Waveform Data";
+        dct:identifier "https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/001/LMU";
+        dct:description "Continuous seismic waveforms";
+        adms:identifier [ a adms:Identifier ;
+        adms:schemaAgency "DDSS-ID" ;
+        skos:notation "WP8-DDSS-001" ;
+        ];
+        dct:created "2016-01-01T00:00:00Z"^^xsd:dateTime ;
+        dct:issued "2016-01-01T00:00:00Z"^^xsd:dateTime ;
+        dct:modified "2016-01-01T00:00:00Z"^^xsd:dateTime ;
+        owl:versionInfo "1.0.0" ;
+
+    	dct:type "http://purl.org/dc/dcmitype/Collection"^^xsd:anyURI;
+        dct:accrualPeriodicity "http://purl.org/cld/freq/continuous"^^xsd:anyURI;
+        dcat:theme  <epos:SeismicWaveforms> ;
+        dcat:keyword "seismology", "seismicity", "earthquakes", "seismic waveform", "seismic hazard", "earth structure", "earthquake intensity", "macroseismic", "macroseismic information", "waveform modeling", "LMU" , "Dataselect", "FDSN-WS", "Seismic Waveform", "EIDA" ;
+        dcat:contactPoint <https://orcid.org/0000-0002-4088-1792/contactPoint>;
+	dct:publisher <PIC:999978433>;
+        dcat:distribution <https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/001/Distribution/001/LMU>;
+        dct:spatial [ a dct:Location ;
+                      locn:geometry "POLYGON(-180.0 -90.0,180.0 -90.0,180.0 90.0,-180.0 90.0,-180.0 -90.0)"^^gsp:wktLiteral;
+        ];
+        dct:temporal [ a dct:PeriodOfTime ;
+                schema:startDate "1980-01-01T00:00:00Z"^^xsd:dateTime ;
+                #schema:endDate "YYYY-MM-DDThh:mm:ssZ"^^xsd:dateTime ;
+	] ;
+.
+
+# Distribution
+<https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/001/Distribution/001/LMU> a dcat:Distribution;
+    	dct:identifier "https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/001/Distribution/001/LMU";
+	dct:description "Description of Seismic Waveform Distribution :: FDSN DATASELECT ";
+	dct:issued "2017-01-01"^^xsd:date ;
+	dct:modified "2017-01-01"^^xsd:date ;
+	dct:type "http://publications.europa.eu/resource/authority/distribution-type/WEB_SERVICE"^^xsd:anyURI;
+	dcat:accessURL <https://www.epos-eu.org/epos-dcat-ap/Seismology/WebService/001/Operation/001/LMU>;
+	dct:conformsTo <https://www.epos-eu.org/epos-dcat-ap/Seismology/WebService/001/LMU>;
+	dct:format "http://publications.europa.eu/resource/authority/file-type/BIN"^^xsd:anyURI;
+ 	dct:license "http://creativecommons.org/licenses/by/4.0/"^^xsd:anyURI ;
+
+.
+
+
+# Dataset
+<https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/002/LMU> a dcat:Dataset;
+        dct:title "Primary Seismic Waveform Data";
+        dct:identifier "https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/002/LMU";
+        dct:description "Seismic Stations ";
+        adms:identifier [ a adms:Identifier ;
+            adms:schemaAgency "DDSS-ID" ;
+            skos:notation "WP8-DDSS-002" ;
+        ];
+        dct:created "2016-01-01T00:00:00Z"^^xsd:dateTime ;
+        dct:issued "2016-01-01T00:00:00Z"^^xsd:dateTime ;
+        dct:modified "2016-01-01T00:00:00Z"^^xsd:dateTime ;
+        owl:versionInfo "1.0.0" ;
+
+    	dct:type "http://purl.org/dc/dcmitype/Collection"^^xsd:anyURI;
+        dct:accrualPeriodicity "http://purl.org/cld/freq/irregular"^^xsd:anyURI;
+        dcat:theme  <epos:Seismicstations> ;
+        dcat:keyword "seismology", "seismicity", "earthquakes", "seismic station", "seismic hazard", "earth structure", "earthquake intensity", "macroseismic", "station information", "waveform modeling", "LMU" , "Station", "FDSN-WS", "Seismic Station", "EIDA" ;
+        dcat:contactPoint <https://orcid.org/0000-0002-4088-1792/contactPoint>;
+	dct:publisher <PIC:999978433>;
+        dcat:distribution <https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/002/Distribution/002/LMU>;
+        dct:spatial [ a dct:Location ;
+											locn:geometry "POLYGON(-180.0 -90.0,180.0 -90.0,180.0 90.0,-180.0 90.0,-180.0 -90.0)"^^gsp:wktLiteral;
+        ];
+        dct:temporal [ a dct:PeriodOfTime ;
+                schema:startDate "1980-01-01T00:00:00Z"^^xsd:dateTime ;
+                #schema:endDate "YYYY-MM-DDThh:mm:ssZ"^^xsd:dateTime ;
+	];
+.
+
+# Distribution
+<https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/002/Distribution/002/LMU> a dcat:Distribution;
+    	dct:identifier "https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/002/Distribution/002/LMU";
+	dct:description "Description of Seismic Stations  :: FDSN STATION ";
+	dct:issued "2017-01-01"^^xsd:date ;
+	dct:modified "2017-01-01"^^xsd:date ;
+	dct:type "http://publications.europa.eu/resource/authority/distribution-type/WEB_SERVICE"^^xsd:anyURI;
+	dcat:accessURL <https://www.epos-eu.org/epos-dcat-ap/Seismology/WebService/002/Operation/002/LMU>;
+	dct:conformsTo <https://www.epos-eu.org/epos-dcat-ap/Seismology/WebService/002/LMU>;
+	dct:format "http://publications.europa.eu/resource/authority/file-type/XML"^^xsd:anyURI;
+ 	dct:license "http://creativecommons.org/licenses/by/4.0/"^^xsd:anyURI ;
+	
+	
+	dcat:contactPoint <https://orcid.org/0000-0002-4088-1792/contactPoint>;
+. 
+	<https://orcid.org/0000-0002-4088-1792/contactPoint> a schema:ContactPoint;
+		schema:email "j.wassermann@lmu.de";
+		schema:availableLanguage "en" ;
+. 
+	<https://orcid.org/0000-0002-4088-1792/legalContact> a schema:ContactPoint;
+		schema:email "j.wassermann@lmu.de";
+		schema:availableLanguage "en" ;
+		schema:contactType "legalContact" ;
+.


### PR DESCRIPTION
Used the [current NIEP one as a template](https://github.com/epos-eu/EPOS-DCAT-AP/blob/6e8020c0d98a7f5ae4b3bbe052890693ec39d4df/examples/WP08/WP8-NIEP-20180913.ttl).

This still has some warnings and also violations, I might be able to fix them tomorrow (kind of inherited this task, not working on EPOS myself).

I'm also unsure about this piece at the moment..

```
431     #schema:identifier [ a schema:PropertyValue; 
432         #schema:propertyID  "DDSS-ID"; 
433         #schema:value  ""; 
434     #]; 
```

..and also this one

```
509         adms:identifier [ a adms:Identifier ;
510         adms:schemaAgency "DDSS-ID" ;
511         skos:notation "WP8-DDSS-001" ;
512         ];
```

..this looks like it should be unique across all data centers and right now it isn't.

We also have an `event` FDSNWS, but I'm not sure if it's supposed to be part of the LMU EPOS contribution, probably not.. and there's the EIDA routing webservice, not sure if that should be included here. See https://erde.geophysik.uni-muenchen.de/

CC @jwassermann @aschloem

<details>
  <summary>Warnings/Violations</summary>
  <p>

```
[
	a sh:ValidationResult ;
	sh:resultSeverity sh:Warning ;
	sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
	sh:sourceShape _:n208 ;
	sh:focusNode <PIC:999978433> ;
	sh:resultPath schema:leiCode ;
	sh:resultMessage "LeiCode is recommended. Please fill in a value"@en ;
] .
[
	a sh:ValidationResult ;
	sh:resultSeverity sh:Warning ;
	sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
	sh:sourceShape _:n226 ;
	sh:focusNode <https://orcid.org/0000-0002-4088-1792/contactPoint> ;
	sh:resultPath schema:contactType ;
	sh:resultMessage "contactType is recommended. Please fill in a value (i.e., legalContact OR financialContact OR scientificContact OR manager"@en ;
] .
[
	a sh:ValidationResult ;
	sh:resultSeverity sh:Warning ;
	sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
	sh:sourceShape _:n243 ;
	sh:focusNode <urn:x-shacl:dataGraph/erde.geophysik.uni-muenchen.de/eidaws/wfcatalog/1/query> ;
	sh:resultPath _:n244 ;
	sh:resultMessage "Contact Point is recommended. Please fill in a value"@en ;
] .
[
	a sh:ValidationResult ;
	sh:resultSeverity sh:Warning ;
	sh:sourceConstraintComponent sh:ClassConstraintComponent ;
	sh:sourceShape _:n356 ;
	sh:focusNode <https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/001/LMU> ;
	sh:value <epos:SeismicWaveforms> ;
	sh:resultPath dcat:theme ;
	sh:resultMessage "Theme is recommended. Please fill in a value"@en ;
] .
[
	a sh:ValidationResult ;
	sh:resultSeverity sh:Warning ;
	sh:sourceConstraintComponent sh:ClassConstraintComponent ;
	sh:sourceShape _:n356 ;
	sh:focusNode <https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/002/LMU> ;
	sh:value <epos:Seismicstations> ;
	sh:resultPath dcat:theme ;
	sh:resultMessage "Theme is recommended. Please fill in a value"@en ;
] .
[
	a sh:ValidationResult ;
	sh:resultSeverity sh:Violation ;
	sh:sourceConstraintComponent sh:OrConstraintComponent ;
	sh:sourceShape _:n412 ;
	sh:focusNode <https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/001/Distribution/001/LMU> ;
	sh:value <https://www.epos-eu.org/epos-dcat-ap/Seismology/WebService/001/Operation/001/LMU> ;
	sh:resultPath dcat:accessURL ;
] .
[
	a sh:ValidationResult ;
	sh:resultSeverity sh:Violation ;
	sh:sourceConstraintComponent sh:OrConstraintComponent ;
	sh:sourceShape _:n417 ;
	sh:focusNode <https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/001/Distribution/001/LMU> ;
	sh:value <https://www.epos-eu.org/epos-dcat-ap/Seismology/WebService/001/LMU> ;
	sh:resultPath dct:conformsTo ;
] .
[
	a sh:ValidationResult ;
	sh:resultSeverity sh:Warning ;
	sh:sourceConstraintComponent sh:OrConstraintComponent ;
	sh:sourceShape _:n421 ;
	sh:focusNode <https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/001/Distribution/001/LMU> ;
	sh:value <https://www.epos-eu.org/epos-dcat-ap/Seismology/WebService/001/LMU> ;
	sh:resultPath dct:conformsTo ;
	sh:resultMessage "Linked schemas (conformsTo) is recommended. Please fill in a value"@en ;
] .
[
	a sh:ValidationResult ;
	sh:resultSeverity sh:Violation ;
	sh:sourceConstraintComponent sh:OrConstraintComponent ;
	sh:sourceShape _:n412 ;
	sh:focusNode <https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/002/Distribution/002/LMU> ;
	sh:value <https://www.epos-eu.org/epos-dcat-ap/Seismology/WebService/002/Operation/002/LMU> ;
	sh:resultPath dcat:accessURL ;
] .
[
	a sh:ValidationResult ;
	sh:resultSeverity sh:Violation ;
	sh:sourceConstraintComponent sh:OrConstraintComponent ;
	sh:sourceShape _:n417 ;
	sh:focusNode <https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/002/Distribution/002/LMU> ;
	sh:value <https://www.epos-eu.org/epos-dcat-ap/Seismology/WebService/002/LMU> ;
	sh:resultPath dct:conformsTo ;
] .
[
	a sh:ValidationResult ;
	sh:resultSeverity sh:Warning ;
	sh:sourceConstraintComponent sh:OrConstraintComponent ;
	sh:sourceShape _:n421 ;
	sh:focusNode <https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/002/Distribution/002/LMU> ;
	sh:value <https://www.epos-eu.org/epos-dcat-ap/Seismology/WebService/002/LMU> ;
	sh:resultPath dct:conformsTo ;
	sh:resultMessage "Linked schemas (conformsTo) is recommended. Please fill in a value"@en ;
] .
```

</p></details>