### PR TITLE
Fix webservice.py to handle repeated parameters in url

### DIFF
--- a/tools/check_webservice/webservice.py
+++ b/tools/check_webservice/webservice.py
@@ -91,7 +91,7 @@ class Operation:
         # Are there any parameters embedded in the URL?
         # If so extract them and add them to the other parameters
         if '{' in self.base_url:
-            self.path_params = re.findall(r'\{.*?\}', self.base_url)
+            self.path_params = set(re.findall(r'\{.*?\}', self.base_url))
             logging.debug("Path parameters: " + str(self.path_params))
             for p in self.path_params:
                 self.parameters.add(p.lstrip('{').rstrip('}').strip())

--- a/tools/check_webservice/webservice.py
+++ b/tools/check_webservice/webservice.py
@@ -38,7 +38,7 @@ class DefaultValueException(Exception):
 
 
 # A subclass of rdflib's Graph that allows basic subgraphing.
-class Subgraphable_Graph(Graph):
+class SubgraphableGraph(Graph):
 
     # Create a subgraph from a triple by recursing
     # through the subgraph using the BNodes.
@@ -166,7 +166,7 @@ class Operation:
 def test_operation(filename):
     logging.info(f"\nProcessing: {filename}")
     logging.info("-"*50)
-    graph = Subgraphable_Graph()
+    graph = SubgraphableGraph()
     graph.parse(location=filename, format='n3')
     operations =  graph.triples((None, HYDRA.property, None))
 


### PR DESCRIPTION
This fix  deals with multiple embedded parameters in urls, i.e. of the form:
```
http://mt.bgs.ac.uk/{project}/{survey}/TF/{project}{survey}_{site}.ts.json
```