### PR TITLE
Bugfix 431-IriTemplateMappingShape-dublicate-entry-for-range

### DIFF
--- a/epos-dcat-ap_shapes.ttl
+++ b/epos-dcat-ap_shapes.ttl
@@ -841,11 +841,6 @@ epos:IriTemplateMappingShape
       sh:maxCount 1 ;   
   ] ;
   sh:property [
-      sh:path rdfs:range ;
-      sh:datatype xsd:string ;
-      sh:maxCount 1 ;   
-  ] ;
-  sh:property [
       sh:path schema:defaultValue ;
       sh:datatype xsd:string ;
       sh:maxCount 1 ;   


### PR DESCRIPTION
This will remove a entry for the path rdfs:range in the IriTemplateMappingShape that is not necessary.