### PR TITLE
fix missing "ao" prefix

### DIFF
--- a/examples/EPOS-DCAT-AP_metadata_template.ttl
+++ b/examples/EPOS-DCAT-AP_metadata_template.ttl
@@ -16,6 +16,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix gsp: <http://www.opengis.net/ont/geosparql#> .
 @prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
 
 
 <https://www.epos-eu.org/epos-dcat-ap/Seismology/Dataset/001> a dcat:Dataset ;


### PR DESCRIPTION
Fix no "ao" prefix information in EPOS-DCAT-AP_metadata_template.ttl.